### PR TITLE
Revise section limits

### DIFF
--- a/AT-HHStA/SbgDK/AUR_0985_X_17.cei.xml
+++ b/AT-HHStA/SbgDK/AUR_0985_X_17.cei.xml
@@ -85,9 +85,9 @@
                         <cei:publicatio>Omnibus<cei:sup>a)</cei:sup> fidelibus nostris presentibus
                             atque futuris notum esse volumus,</cei:publicatio>
                         <cei:narratio> quomodo nos ob interventum Heinrici Karigentinorum<cei:sup>b)
-                            </cei:sup>ducis cuidam fideli nostro Rachuuin<cei:sup>c)</cei:sup>
-                            nominato</cei:narratio>
-                        <cei:dispositio> de nostra proprietate dedimus quindecim mansos
+                            </cei:sup>ducis</cei:narratio>
+                        <cei:dispositio> cuidam fideli nostro Rachuuin<cei:sup>c)</cei:sup>
+                            nominato de nostra proprietate dedimus quindecim mansos
                                 regales<cei:sup>d)</cei:sup> in villa Razuuai dicta sitos si ibi
                             inveniantur, si autem ibi inveniri non possint, in proximis villis, ubi
                             suppleri valeant tollendos et in pago Zitilinesfeld<cei:sup>e)</cei:sup>

--- a/AT-HHStA/SbgDK/AUR_1006_XII_07.cei.xml
+++ b/AT-HHStA/SbgDK/AUR_1006_XII_07.cei.xml
@@ -79,12 +79,13 @@
                         <cei:publicatio> Quapropter generaliter omnium pateat
                             industriae,</cei:publicatio>
                         <cei:narratio>qualiter nos interveniente dilecta<cei:sup>b</cei:sup>)
-                            coniuge nostra Cunigunda videlicet regina quoddam nostri iuris predium
+                            coniuge nostra Cunigunda videlicet regina</cei:narratio>
+                        <cei:dispositio> quoddam nostri iuris predium
                             Slierbach dictum in comitatu Radpotonis situm, in pago vero
-                                Oliupestale<cei:sup>c)</cei:sup> Iubensi
-                                acclesiae<cei:sup>d</cei:sup>), ubi sanctus Rodbertus corporaliter
-                            requiescit, pro redemptione animae nostrae dilectaeque coniugis </cei:narratio>
-                        <cei:dispositio>per hoc regale testamentum donando firmamus, cum omnibus
+                            Oliupestale<cei:sup>c)</cei:sup> Iubensi
+                            acclesiae<cei:sup>d</cei:sup>), ubi sanctus Rodbertus corporaliter
+                            requiescit, pro redemptione animae nostrae dilectaeque coniugis
+							per hoc regale testamentum donando firmamus, cum omnibus
                             appendiciis et utilitatibus eidem predio adiacentibus cum familia
                             utriusque sexus, cum areis aedificiis terris
                                 culltis<cei:sup>d)</cei:sup> et incultis, viis inviis, exitibus et

--- a/AT-HHStA/SbgDK/AUR_1014_VI_21.cei.xml
+++ b/AT-HHStA/SbgDK/AUR_1014_VI_21.cei.xml
@@ -105,9 +105,9 @@
                     <cei:context>
                         <cei:publicatio>Sciant omnes fideles nostri presentes pariter atque
                             futuri,</cei:publicatio>
-                        <cei:narratio> qualiter nos cum venerabili archiepiscopo Salzburgensi
-                            Hardauuigo nomine concambium quoddam fecimus.</cei:narratio>
-                        <cei:dispositio> Nam Ungaricus<cei:sup>a)</cei:sup> quidam Martinus nomine
+                        <cei:dispositio> qualiter nos cum venerabili archiepiscopo Salzburgensi
+                            Hardauuigo nomine concambium quoddam fecimus. Nam Ungaricus
+							<cei:sup>a)</cei:sup> quidam Martinus nomine
                             ancilla ipsius in coniugium accepta ex ea filios procreavit, quorum
                             nomina hec sunt: Reginpreht<cei:sup>b) </cei:sup>Vuerenpurch Vviginan
                             Hereman Nazo, quos postea ab innata servitute pro helemosina nostra

--- a/AT-HHStA/SbgDK/AUR_1020_IV_23.cei.xml
+++ b/AT-HHStA/SbgDK/AUR_1020_IV_23.cei.xml
@@ -87,16 +87,16 @@
                             pateat,</cei:publicatio>
                         <cei:narratio> qualiter nos per interventum ac petitionem carae coniugis
                             nostrae Chvnigvndae scilicet imperatricis augustae ac dilecti cappellani
-                            nostri Aribonis ad dotandum sanctae Iuuauensis aecclesiae monasterium a
+                            nostri Aribonis</cei:narratio>
+                        <cei:dispositio> ad dotandum sanctae Iuuauensis aecclesiae monasterium a
                             venerabili Hartvvico eiusdem loci archiepiscopo in honorem principis
                             apostolorum Petri sanctique Rvodberti renovatum VI regales mansos in
                             capite fluminis cuiusdam vulgari nomine Viscaha vocati sitos, ubi
-                                vetustisimi<cei:sup>b)</cei:sup> antiquitus constructae aecclesiae
+                            vetustisimi<cei:sup>b)</cei:sup> antiquitus constructae aecclesiae
                             adhuc manent muri, cum omni legalitate, scilicet pratis pascuis silvis
                             venationibus piscationibus aquis aquarumque decursibus molendinis agris
                             cultis et incultis, exitibus et reditibus et cum omnibus utensilibus ad
-                            praedictos mansos pertinentibus,</cei:narratio>
-                        <cei:dispositio> regali ac imperiali potestate nostra in proprium
+                            praedictos mansos pertinentibus, regali ac imperiali potestate nostra in proprium
                             concessimus atque donavimus ea ratione, ut praenominati monasterii
                             episcopus suique successores liberam exinde potestatem habeant utendi
                             mutandi ad usum scilicet eiusdem monasterii.</cei:dispositio>

--- a/AT-HHStA/SbgDK/AUR_1027_VII_26.cei.xml
+++ b/AT-HHStA/SbgDK/AUR_1027_VII_26.cei.xml
@@ -82,8 +82,8 @@
                         <cei:publicatio> Notum esse cupimus omnibus Christi nostrique fidelibus
                             praesentibus et futuris,</cei:publicatio>
                         <cei:narratio> qualiter nos per interventum dilectissimae nostrae coniugis
-                            Gislae necnon dilecti nostri Aribonis Mogontini</cei:narratio>
-                        <cei:dispositio> protopraesulis Thietmaro Salzburgensis ecclesiae venerabili
+                            Gislae necnon dilecti nostri Aribonis Mogontini protopraesulis</cei:narratio>
+                        <cei:dispositio> Thietmaro Salzburgensis ecclesiae venerabili
                             archiepiscopo cunctisque suis successoribus forestum, quod est situm ab
                             ecclesia sancti Martini, quae est in monte ubi sanctimoniales sunt
                             contra * Nocsten *, ex utraque parte fluminis Iuaris nominati usque in

--- a/AT-HHStA/SbgDK/AUR_1045_XII_07.cei.xml
+++ b/AT-HHStA/SbgDK/AUR_1045_XII_07.cei.xml
@@ -80,12 +80,12 @@
                             presentium sollers industria noverit, </cei:publicatio>
                         <cei:narratio>qualiter nos ob interventum et peticionem Agnetis regine
                             nostrae contectalis dilectae necnon ob amorem et fidele obsequium
-                            Balvvini venerabilis archiepiscopi Salzpvrgensis sedis tale predium,
+                            Balvvini venerabilis archiepiscopi Salzpvrgensis sedis</cei:narratio>
+                        <cei:dispositio>  tale predium,
                             quale visi sumus Livtoldasdorf habere, in comitatu Gotefridi marchionis,
                             et foresto Svsel iuxta litus Losnicae [flumi]nis situm prenominate sedi
                             et aecclesiae videlicet in honore sancti Petri piique Rovdberti
-                            constructae</cei:narratio>
-                        <cei:dispositio> atque Baldvvino eiusdem aecclesia[e archipre]suli regia
+                            constructaeatque Baldvvino eiusdem aecclesia[e archipre]suli regia
                             nostra benivolentia et auctoritate de nostro [iure] et dominio in eius
                             ius et dominium liberaliter tranfudimus<cei:sup>a)</cei:sup> cum omnibus
                             suis app[enditiis, cum ar]eis aedificiis terris cultis et incultis

--- a/AT-HHStA/SbgDK/AUR_1055_III_22.cei.xml
+++ b/AT-HHStA/SbgDK/AUR_1055_III_22.cei.xml
@@ -95,11 +95,11 @@
                         <cei:narratio> qualiter nos pro remedio anime nostrae et incolomitate ac
                             peticione consortis regni thorique nostri Agnetis imperatricis necnon
                             pro saluto et intercessione filii [nostri Hein]rici quarti regis atque
-                            ob interventum Salzpurgensis episcopi nomine Baldevvini deo nobisque
+                            ob interventum Salzpurgensis episcopi nomine Baldevvini</cei:narratio>
+                        <cei:dispositio>  deo nobisque
                             fidi quoddam predium Potonis, rei maiestatis et in palatino placito
                             dampnati atque proscripti, quod nostrae potestati lege adiudicatum
-                            est,</cei:narratio>
-                        <cei:dispositio> in loco Isingrimesheim dicto iuxta Marchluppam fluvium
+                            est,in loco Isingrimesheim dicto iuxta Marchluppam fluvium
                             situm in pago Mathgeuue et hobas atque duas curtiles causas ad ipsum
                             predium pertinentes ad titulum sancti Petri et sancti Rotperti, quorum
                             honore Salzburgense monasterium constructum est, ad eundem locum in

--- a/AT-HHStA/SbgDK/AUR_1056_VII_03.cei.xml
+++ b/AT-HHStA/SbgDK/AUR_1056_VII_03.cei.xml
@@ -87,14 +87,15 @@
                             futuris quam praesentibus,</cei:publicatio>
                         <cei:narratio> qualiter nos propter dei amorem et aeternam remunerationem et
                             per interventum contectalis nostrae scilicet Agnetis imperatricis
-                            augustae nostrique filii dilectissimi Heinrici quarti regis sanctae
+                            augustae nostrique filii dilectissimi Heinrici quarti regis</cei:narratio>
+                        <cei:dispositio> sanctae
                             Salzburgensi ecclesiae tres regales mansos in loco Gumbrahtdessteiden
                             sitos cum omnibus suis pertinentiis, hoc est areis aedifitiis terris
                             cultis et incultis agris pratis pascuis campis silvis venationibus aquis
                             aquarumque decursibus molis molendinis piscationibus exitibus et
                             reditibus, viis et inviis, quesitis et inquirendis ac cum omni
-                            utilitate, quae ullo modo inde provenire potest</cei:narratio>
-                        <cei:dispositio> in proprium dedimus atque tradidimus ea videlicet ratione,
+                            utilitate, quae ullo modo inde provenire potest in proprium dedimus
+							atque tradidimus ea videlicet ratione,
                             ut venerabilis archiepiscopus Baldinc nominatus, cuius peticione hec
                             traditio facta est, cunctique sui successores de eodem predio liberam
                             dehinc potestatem habeant tenendi dandi commutandi praecariandi vel

--- a/AT-HHStA/SbgDK/AUR_1056_VII_04.cei.xml
+++ b/AT-HHStA/SbgDK/AUR_1056_VII_04.cei.xml
@@ -91,10 +91,11 @@
                             nostrisque fidelibus tam futuris quam presentibus,</cei:publicatio>
                         <cei:narratio> qualiter pro remedio anime nostre et ob interventum
                             dilectissime coniugis nostre imperatricis Agnetis necnon petitionem
-                            filii nostri karissimi Heinrici quarti regis quoddam predium nomino
+                            filii nostri karissimi Heinrici quarti regis</cei:narratio>
+                        <cei:dispositio> quoddam predium nomino
                             Naunzel, quod Durdogouuo Ozino comiti dederat et quod Otto filius
-                            eiusdem Ozini nobis per cartulam tradiderat,</cei:narratio>
-                        <cei:dispositio> in pago Foro Iulio et in comitatu Lvdowici comitis situm
+                            eiusdem Ozini nobis per cartulam tradiderat, in pago Foro Iulio et
+							in comitatu Lvdowici comitis situm
                             sancte Salzbvrgensi ecclesie concedimus donamus et confirmamus ea
                             videlicet racione, ut nullus archiepiscopus episcopus dux marchio comes
                             vicecomes nec aliqua magna vel parva nostri regni persona predictam

--- a/AT-HHStA/SbgDK/AUR_1059_VI_01.cei.xml
+++ b/AT-HHStA/SbgDK/AUR_1059_VI_01.cei.xml
@@ -88,7 +88,8 @@
                             presentibus notum esse volumus,</cei:publicatio>
                         <cei:narratio> qualiter nos ob interventum ac petitionem dilectissimae
                             genitricis nostrae Agnetis imperatricis augustae nec non ob fidele
-                            servicium Baltwini Salzburgensis archiepiscopi quinque mansos habitatos
+                            servicium Baltwini Salzburgensis archiepiscopi </cei:narratio>
+                        <cei:dispositio> quinque mansos habitatos
                             in marchionis Otacheres marchia Carintina in villa autem Gunprehtesteten
                             sitos, si ex integro in eadem mensurari possent, sin autem minus, in
                             proximis superioribus eiusdem villae partibus iuxta flumen Lonsinice in
@@ -96,8 +97,8 @@
                             sexus mancipiis areis aedificiis terris cultis et incultis, agris pratis
                             pascuis campis silvis venationibus aquis aquarumque decursibus molis
                             molendinis piscationibus exitibus ac reditibus, viis et inviis, quesitis
-                            et inquirendis cum omni utilitate, que ullo modo inde provenire potest, </cei:narratio>
-                        <cei:dispositio>sanctae dei ecclesiae ad altare sancti Roperti confessoris
+                            et inquirendis cum omni utilitate, que ullo modo inde provenire potest,
+							sanctae dei ecclesiae ad altare sancti Roperti confessoris
                             in loco Salzburc dicto in proprium dedimus atque tradidimus ea videlicet
                             ratione, ut predictus archiepiscopus ceterique sui successores de
                             prefato predio liberam dehinc potestatem habeant tenendi commutandi

--- a/AT-HHStA/SbgDK/AUR_1062_VIII_23.cei.xml
+++ b/AT-HHStA/SbgDK/AUR_1062_VIII_23.cei.xml
@@ -87,17 +87,17 @@
                             humiliter adiit rogans, quatinus pro remedio animae patris nostri
                             Heinrici imperatoris nostramque salutem omnia aecclesiae suae bona in
                             nostrum mundiburdium reciperemus ac more antecessorum nostrorum regum
-                            seu imperatorum precepto nostro confirmaremus. Nos vero petitionem eius
-                            iustam cognoscentes fidelium nostrorum consilio benignum assensum super
-                            hac re prebuimus atque eadem bona, que vel ipse aut antecessores sui
-                            proprie infra suam parrochiam hactenus possiderunt<cei:sup>a)</cei:sup>
-                            aut quarum investituram habuerunt, cum omnibus suis pertinentiis hoc est
-                            utriusque sexus familiis areis aedificiis terris cultis et incultis
-                            agris pratis pascuis campis silvis venationibus forestis piscationibus
-                            aquis aquarumve decursibus monetis theloneis aecclesiis decimationibus
-                            molis molendinis exitibus et reditibus, quaesitis et inquirendis seu cum
-                            omni utilitate, que ullo modo inde provenire potest,</cei:narratio>
-                        <cei:dispositio> in nostram tutionem recepimus ac per huius nostri paginam
+                            seu imperatorum precepto nostro confirmaremus.</cei:narratio>
+                        <cei:dispositio> Nos vero petitionem eius iustam cognoscentes fidelium nostrorum
+							consilio benignum assensum super hac re prebuimus atque eadem bona, que vel
+							ipse aut antecessores sui proprie infra suam parrochiam hactenus possiderunt
+							<cei:sup>a)</cei:sup> aut quarum investituram habuerunt, cum omnibus suis
+							pertinentiis hoc est utriusque sexus familiis areis aedificiis terris cultis
+							et incultis agris pratis pascuis campis silvis venationibus forestis
+							piscationibus aquis aquarumve decursibus monetis theloneis aecclesiis
+							decimationibus molis molendinis exitibus et reditibus, quaesitis et
+							inquirendis seu cum omni utilitate, que ullo modo inde provenire potest,
+							in nostram tutionem recepimus ac per huius nostri paginam
                             precepti aecclesiae suae asscripsimus annuimus atque. corroboravimus.
                             Nominatim autem illa eiusdem aecclesiae suae bona, quae in caeteris
                             parrochiis sunt queque maxime nostrae defensionis indigent, scilicet qua

--- a/AT-HHStA/SbgDK/AUR_1207_XII_10.cei.xml
+++ b/AT-HHStA/SbgDK/AUR_1207_XII_10.cei.xml
@@ -90,7 +90,8 @@
                         <cei:publicatio> Noverint igitur universi fideles imperii tam presentis evi
                             quam futuri,</cei:publicatio>
                         <cei:narratio> quod nos a preces dilecti fidelis nostri Alberti prepositi
-                            Salzeburgensis fratrumque eiusdem capituli pro spe eterne vite omnes
+                            Salzeburgensis fratrumque eiusdem capituli </cei:narratio>
+                        <cei:dispositio> pro spe eterne vite omnes
                             inibi utriusque sexus homines secundum * regulam beati Augustini deo
                             famulantes et divinis serviciis mancipatos et omnia bona eorum mobilia
                             et inmobilia ab antecessoribus nostris et eiusdem loci archiepiscopis
@@ -98,8 +99,7 @@
                             animarum ad sustentationem eis collata sunt, que in presentiarum iuste
                             ac rationabiliter possidere dinoscuntur aut in futurum concessione
                             pontificum, largitione regum vel principum seu oblatione aliorum Christi
-                            fidelium iuste adipisci poterunt, </cei:narratio>
-                        <cei:dispositio>sub * nostra recipimus protectione et regali confirmantes
+                            fidelium iuste adipisci poterunt,sub * nostra recipimus protectione et regali confirmantes
                             auctoritate ipsis eorumque successoribus firma * et illibata decernimus
                             permanere, in quibus hec propriis exprimenda duximus vocabulis: locum
                             ipsum, in quo ecclesia Salzpurgensis episcopalis sita est et a nostris

--- a/AT-HHStA/SbgE/AUR_0977_X_01.cei.xml
+++ b/AT-HHStA/SbgE/AUR_0977_X_01.cei.xml
@@ -94,11 +94,11 @@
                             aeclesiam sancti Petri * sanctique Rodberti confessoris Christi, ubi
                             ipse corporaliter requiescit, cui predictus * archiepiscopus preesse
                             videtur, fidelium suorum petitionibus concesserunt, a nobis etiam
-                            firmarentur. Cuius petitioni ob amorem domini nostri Iesu Christi et ob
+                            firmarentur.</cei:narratio>
+                        <cei:dispositio> Cuius petitioni ob amorem domini nostri Iesu Christi et ob
                             remedium animarum antecessorum nostrorum ac beate memoriae domni ac
                             genitoris nostri nostraeque etiam mercedis augmentum libenti animo
-                            assensum prebentes id ita fieri decrevimus.</cei:narratio>
-                        <cei:dispositio>Ideoque firmamus ad predictum monasterium sancti Petri
+                            assensum prebentes id ita fieri decrevimus.Ideoque firmamus ad predictum monasterium sancti Petri
                             sanctique Rodperti primitus castellum sanctae Erindrudis cum omnibus
                             iuste ac legaliter ad idem castellum pertinentibus, cum curtibus
                             venationibus piscationibus, id est ab aeclesia sancti Martini, que

--- a/AT-HHStA/SbgE/AUR_0982_V_18.cei.xml
+++ b/AT-HHStA/SbgE/AUR_0982_V_18.cei.xml
@@ -154,7 +154,8 @@
                             dominationis regia auctoritate confirmavit. Sed pro rei statu et
                             firmitate nostram humiliter rogavit celsitudinem, ut nos denuo illius
                             donationis traditionem et confirmationem imperiali magnitudine nostrae
-                            munificentiae cunfirmaremus. Cuius petitioni vero piae ob votum et
+                            munificentiae cunfirmaremus.</cei:narratio>
+                        <cei:dispositio> Cuius petitioni vero piae ob votum et
                             intercessionem, ut antedictum est, care contectalis nostrae Theophanu
                             scilicet imperatricis augustae ac fidelis nostri Deoderici iam dictae
                             Mettensis ecclesie episcopi assensum praebentes, quicquid praefatus
@@ -162,8 +163,8 @@
                             principis apostolorum, et sancti Rotberti, confessoris Christi luuauia
                             civitate, cuius corpus etiam ibi iacet, constructam ac consecratam dedit
                             et confirmavit, aut alii antecessores sive successores illius illuc
-                            tradiderunt, parvum cum magno,</cei:narratio>
-                        <cei:dispositio>totum a novo imperiali celsitudinis nostrae auctoritate ad
+                            tradiderunt, parvum cum magno,totum a novo imperiali celsitudinis nostrae
+							auctoritate ad
                             integrum concedimus ac confirmamus, ea videlicet ratione, ut ab hodierna
                             die et deinceps predicte res, sicut ab antiquis regibus videlicet vel
                             imperatoribus et noviter a nobis tradite et confirmate sunt, sub

--- a/AT-HHStA/SbgE/AUR_0996_V_28.cei.xml
+++ b/AT-HHStA/SbgE/AUR_0996_V_28.cei.xml
@@ -78,9 +78,9 @@
                             astantium, ipsius quoque summi apostolici Gregorii, Romanorum,
                             Francorum, Bauuariorum, Saxonum, Alsatiensium, Sueuorum, Lutharingorum
                             ob remedium animae nostrae nostrorumque parentum necnon et interventum
-                            ac petitionem Hartuuici archiepiscopi Salzpurcgensis aecclesiae talem
-                            utilitatem ac tantum honorem,</cei:narratio>
-                        <cei:dispositio> id est mercatum omni die legitimum monetam Radesponensem in
+                            ac petitionem Hartuuici archiepiscopi Salzpurcgensis aecclesiae</cei:narratio>
+                        <cei:dispositio> talem utilitatem ac tantum honorem, id est mercatum omni
+							die legitimum monetam Radesponensem in
                             loco Salzpurc dicto imperiali potentia construi et ad prime incoeptari
                             concessimus; theloneum autem nos exinde respitientem super gremium
                             sancti Petri sanctique Ruodberti pro salute corporis nostri et animae

--- a/AT-HHStA/SbgE/AUR_1051_II_08.cei.xml
+++ b/AT-HHStA/SbgE/AUR_1051_II_08.cei.xml
@@ -87,11 +87,11 @@
                             aecclesiam sancti Petri sanctique Rodberti confessoris Christi, ubi
                             corporaliter requiescit et ipse * venerabilis archiepiscopus preest,
                             fidelium suorum petitionibus concesserunt, a nobis quoque renovata
-                            firmarentur. Cuius petitioni ob amorem domini nostri Iesu Christi seu ob
+                            firmarentur. </cei:narratio>
+                        <cei:dispositio> Cuius petitioni ob amorem domini nostri Iesu Christi seu ob
                             remedium animarum antecessorum nostrorum et beate memoriae domni ac
                             genitoris nostri nostraeque mercedis augmentum libenti animo assensum
-                            prebentes decrevimus ita fieri.</cei:narratio>
-                        <cei:dispositio> Renovamus igitur atque confirmamus ad predictum monasterium
+                            prebentes decrevimus ita fieri.Renovamus igitur atque confirmamus ad predictum monasterium
                             sancti Petri sanctique Rotberti primitus castellum sancte Erindrudis cum
                             omnibus ad idem castellum iuste ac legaliter pertinentibus, cum curtibus
                             piscationibns venationibus, id est ab aecclesia sancti Martini que

--- a/AT-HHStA/SbgE/AUR_1055_III_06.cei.xml
+++ b/AT-HHStA/SbgE/AUR_1055_III_06.cei.xml
@@ -83,7 +83,7 @@
                             accrescere.</cei:arenga>
                         <cei:publicatio>Proinde noverit omnium Christi nostrique fidelium
                             industria,</cei:publicatio>
-                        <cei:narratio> qualiter nos pro remedio animarum omnium antecessorum
+                        <cei:dispositio> qualiter nos pro remedio animarum omnium antecessorum
                             nostrorum et nostri et pro vite nostrae coniugisque nostrae Agnetis et
                             dilectissimae prolis Heinrici regis quarti incolumitate et regni nostri
                             stabilitate precante Beldingo archiepiscopo atque fideli servitio suo
@@ -93,8 +93,7 @@
                             cum omnibus suis iusticiis et pertinentiis, et quicquid Botonis
                             diiudicati atqne proscripti erat inter fluvium Mora et inter predictum
                             locum Strazkang, quod nostrae imperiali potestati in palatino placito
-                            adiudicatum est,</cei:narratio>
-                        <cei:dispositio> tradidimus in proprium cum omnibus suis appenditiis, hoc
+                            adiudicatum est, tradidimus in proprium cum omnibus suis appenditiis, hoc
                             est utriusque sexus mancipiis areis aedificiis terris cultis et
                             incultis, pratis pascuis aquis aquarumque decursibus molis molendinis
                             piscationibus silvis venationibus exitibus et reditibus, viis et inviis,

--- a/AT-HHStA/SbgE/AUR_1057_II_04.cei.xml
+++ b/AT-HHStA/SbgE/AUR_1057_II_04.cei.xml
@@ -95,11 +95,11 @@
                             ecclesiam sancti Petri sanctique Rodberti confessoris Christi, ubi
                             corporaliter requiescit et ipse venerabilis archiepiscopus preest,
                             fidelium suorum petitionibus concesserunt, a nobis quoquo renovata
-                            firmarentur. Cuius petitioni ob amorem domini nostri Iesu Christi seu ob
+                            firmarentur.</cei:narratio>
+                        <cei:dispositio> Cuius petitioni ob amorem domini nostri Iesu Christi seu ob
                             remedium animarum antecessorum nostrorum et beate memorie domni ac
                             genitoris nostri nostreque mercedis augmentum libenti animo assensum
-                            prebentes decrevimus ita fieri.</cei:narratio>
-                        <cei:dispositio>Renovamus igitur atque confirmamus ad predictum monasterium
+                            prebentes decrevimus ita fieri.Renovamus igitur atque confirmamus ad predictum monasterium
                             sancti Petri sanctique Rotberti primitus castellum sancte Erindrudis cum
                             omnibus ad idem castellum iuste ac legaliter pertinentibus cum curtibus
                             piscationibus venationibus, id est ab ecclesia sancti Martini quo

--- a/AT-HHStA/SbgE/AUR_1072_II_04.cei.xml
+++ b/AT-HHStA/SbgE/AUR_1072_II_04.cei.xml
@@ -89,9 +89,10 @@
                         <cei:intitulatio> Heinricus divina favente clementia rex.</cei:intitulatio>
                     </cei:protocol>
                     <cei:context>
-                        <cei:narratio>Quotiens ea a nobis petuntur que religioni oouveniunt, prompta
+                        <cei:arenga>Quotiens ea a nobis petuntur que religioni oouveniunt, prompta
                             debemus concessione annuere et favoris nostri gratanter prebere
-                            assensum. Ergo quia fidelis noster Gebehardus Iuuauensis archiepiscopus
+                            assensum.</cei:arenga>
+						<cei:narratio> Ergo quia fidelis noster Gebehardus Iuuauensis archiepiscopus
                             de commissarum sibi animarum periculis dolens conquestus est, quod
                             episcopatum suum in montanis situm pre nimia parrochie amplitudine et
                             viarum difficultate per se solum regere nun sufficeret, consultu

--- a/AT-HHStA/SbgE/AUR_1207_IX_22.cei.xml
+++ b/AT-HHStA/SbgE/AUR_1207_IX_22.cei.xml
@@ -89,7 +89,7 @@
                         <cei:publicatio> Ob memoriam itaque rei geste ad noticiam universorum tam
                             presentis etatis quam in eorum successure posteritatis hominum deduci
                             volumus,</cei:publicatio>
-                        <cei:dispositio> qualiter constitutis in presencia regie maigestatis dilecto
+                        <cei:narratio> qualiter constitutis in presencia regie maigestatis dilecto
                             fideli nostro Eberhardo venerabili Salzpurgensis ecclesie archiepiscopo
                             et Heinrico comite de Lechesgemunde evidentissima veritatis expressione
                             nobis est monstratum, quod inter dominum Cvnradum quondam Salzpurgensem
@@ -123,7 +123,8 @@
                             Lôshant reddidit sibi ministerialem. Denique ut omnem questionis
                             scrupulum rei geste sepedictus comes elideret, donationem ab antiquo
                             Salzpurgensi ecclesie factam in presencia regalis magnificencie
-                            recognovit et eandem donationem denuo libera voluntate innovavit. Hanc
+                            recognovit et eandem donationem denuo libera voluntate innovavit.
+							</cei:narratio><cei:dispositio> Hanc
                             igitur donationem rite et rationabiliter in presencia nostra factam
                             approbamus et regia auctoritate confirmamus statuentes et regia
                             sanctione firmiter precipientes, ut nulli de cetero persone alte vel

--- a/AT-HHStA/SbgE/AUR_1209_II_20.cei.xml
+++ b/AT-HHStA/SbgE/AUR_1209_II_20.cei.xml
@@ -88,14 +88,14 @@
                             semper augustus. ++</cei:intitulatio>
                     </cei:protocol>
                     <cei:context>
-                        <cei:narratio>Regalis excellentie nostre decet equitatem subiectorum
+                        <cei:arenga>Regalis excellentie nostre decet equitatem subiectorum
                             commodis curam diligentem impendere et causas seu etiam lites, quociens
                             coram nobis emerserint, quo pacto decidantur, scripture amminiculo
                             perpetuare, ut inposterum omni careat ambiguitate, quod prius a
-                            plerisque deduci solebat perverse in questionem.</cei:narratio>
+                            plerisque deduci solebat perverse in questionem.</cei:arenga>
                         <cei:publicatio> Eapropter noverit universorum imperii fidelium presens etas
                             et successura posteritas,</cei:publicatio>
-                        <cei:dispositio>quod cum apud No/urinberc imperialem locum sub frequentia
+                        <cei:narratio>quod cum apud No/urinberc imperialem locum sub frequentia
                             principum curiam sollempnem celebraremus, Waltherus venerabilis
                             Gurcensis episcopus una cum ecclesie, sue familia cleri et populi in
                             nostra constitutus presentia exposuit nobis, quod ecclesia Gurcensis eo
@@ -125,7 +125,8 @@
                             principum videlicet Heinrici quarti Rom(anorum) regis et Friderici
                             imperatoris scriptis autenticis et vivo testimonio comprobasset. Quam
                             sententiam universi principes in nostra tunc constituti presentia equam
-                            et semper observandam uno ore firmiter proclamarunt. Nos itaque deo
+                            et semper observandam uno ore firmiter proclamarunt.</cei:narratio>
+							<cei:dispositio> Nos itaque deo
                             nobis auxiliante in cunctis agendis nostris iusticie semitam tenere
                             cupientes hiis et aliis, que dicta fuerunt, auditis et presertim, quia
                             iam dictus Gurcensis episcopus coram nobis est confessus, quod nec ipse

--- a/AT-OOeLA/GarstenOSB/1142.cei.xml
+++ b/AT-OOeLA/GarstenOSB/1142.cei.xml
@@ -84,9 +84,9 @@
                         <cei:narratio> qualiter nos pro anime nostre remedio necnon interuentu
                             dilecte coniugis nostre Gertrvdis regine et Agnetis karissime matris
                             nostre et assensu dilecti fratris nostri Heinrici marchionis ac humili
-                            petitione Bertolfi uenerabilis abbatis ecclesie Garstensi in honore
-                            sancte dei genitricis Marie consecrate</cei:narratio>
-                        <cei:dispositio> quadringentos mansos in silua nostra, que uocatur Ritmarch
+                            petitione Bertolfi uenerabilis abbatis ecclesie Garstensi</cei:narratio>
+                        <cei:dispositio> in honore sancte dei genitricis Marie consecrate quadringentos
+							mansos in silua nostra, que uocatur Ritmarch
                             uidelicet a fluuio Jowerniz usque ad fluuium Agast et exinde usque ad
                             terminum sclauorum legitima donatione concessimus edicto regali
                             statuentes, quatenus prefatys Bertolfus abbas suique successores et

--- a/AT-OOeLA/MondseeOSB/1104_II_27.cei.xml
+++ b/AT-OOeLA/MondseeOSB/1104_II_27.cei.xml
@@ -80,8 +80,8 @@
                             parentum remedium et ob amorem et salutem heinrici regis dilecti filij
                             nostri et ob deuotam peticionem Rudberti venerabilis abbatis eiusdem
                             loci cenobium Ma<cei:sup>e</cei:sup>nnse constructum in honore sancti
-                            Michahelis archangeli</cei:narratio>
-                        <cei:dispositio> respeximus et bona ecclesie, que vsui fratrum ibi deo
+                            Michahelis archangeli respeximus</cei:narratio>
+                        <cei:dispositio> et bona ecclesie, que vsui fratrum ibi deo
                             seruiencium diu iniuste subtracta fuerant, in presencia
                             archiepiscoporum, episcoporum, comitum et aliorum multorum nostrorum
                             fidelium eidem loco iuste restituimus et habere perpetuo cum pace

--- a/AT-StiAG/GoettweigOSB/1058_X_26.cei.xml
+++ b/AT-StiAG/GoettweigOSB/1058_X_26.cei.xml
@@ -111,8 +111,8 @@
                         <cei:publicatio> | Omnibus Christi nostrique fidelibus tarn futuris quam
                             praesentibus notum esse volumus,</cei:publicatio>
                         <cei:narratio> qualiter nos ob interventum ac petitionem dilectissimae
-                            genitricis nostrae Agnetis imperatricis augustae cuidem fideli nostro
-                            Cvono dicto decem regales mansos in villa
+                            genitricis nostrae Agnetis imperatricis augustae</cei:narratio>
+                        <cei:dispositio> cuidem fideli nostro Cvono dicto decem regales mansos in villa
                                 Gvzbretdesdorf<cei:sup>1</cei:sup> et deorsum Svarzaha et si ibi
                             aliquid defuerit, sursum Svarzaha adimplendos in marcha Karentana et in
                             comitatu Otacheres marchionis sitos cum omnibus suis pertinentiis, hoc
@@ -120,8 +120,7 @@
                             campis silvis venationibus aquis aquarumque decursibus molis molendinis
                             piscationibus exitibus et reditibus viis et inviis quaesitis et
                             inquirendis seu cum omni utilitate, quae ullo modo inde provenire
-                            potest,</cei:narratio>
-                        <cei:dispositio> in proprium dedimus atque tradidimus ea videlicet ratione,
+                            potest, in proprium dedimus atque tradidimus ea videlicet ratione,
                             ut praedictus Cvono de praefato praedio sibi a nobis tradito liberam
                             dehinc potestatem habeat tenendi dandi vendendi commutandi praecariandi
                             posteris relinquendi vel quicquid sibimet placuerit, inde

--- a/AT-StiAG/GoettweigOSB/1108_IX_06.cei.xml
+++ b/AT-StiAG/GoettweigOSB/1108_IX_06.cei.xml
@@ -93,13 +93,13 @@
                         <cei:narratio> qualiter ego Heinricus rex Romanorum ob remedium animê nostrê
                             ac parentum nostrorum et ob peticionem principum nostrorum, videlicet
                                 O<cei:sup>v</cei:sup>udalrici Pataviensis episcopi ac sororis nostrê
-                            Agnetis et mariti eius Luitpoldi marchionis et ducis Welfonis tradidimus
+                            Agnetis et mariti eius Luitpoldi marchionis et ducis Welfonis</cei:narratio>
+                        <cei:dispositio> tradidimus
                             ad altare sanctê Mariê in Chotiuuige insulam, quê vulgo dicitur
                                 Mutheimeruuerth,<cei:sup>1</cei:sup> rogante hoc etiam Adalberto,
                             cuius hec erat beneficium, cum omni utilitate cultis incultis silvis
                             viis inviis pratis pascuis molendinis piscationibus aquis aquarumque
-                            decursibus.</cei:narratio>
-                        <cei:dispositio> Per istam itaque traditionem firmamus et stabilimus,
+                            decursibus. Per istam itaque traditionem firmamus et stabilimus,
                             quicquid episcopus Altmannus eiusdem loci primus fundator ad prêdictam
                             êcclesiam dedit, seu quicunque alius fidelis cuiuscunque conditionis
                             sive ordinis ex quacunque parte Danubii. Hêc autem sunt bona prêdictê

--- a/AT-StiAKr/KremsmuensterOSB/0975_VI_11.cei.xml
+++ b/AT-StiAKr/KremsmuensterOSB/0975_VI_11.cei.xml
@@ -63,9 +63,9 @@
                             imperiali donauerint, obsecrans pietatis nostrae munificentiam, ut eas
                             nostre quoque auctoritatis roboratione renouaremus. Idcirco non suae
                             solum seruitutis assiduitate commoniti sed et interuentu fidelium
-                            nostrorum Willigisi et Gereonis archiepiscoporum incitati iustis eius
-                            praecibus assensum</cei:narratio>
-                        <cei:dispositio> praebuimus et eandem abbatiam cum omnibus iuste et
+                            nostrorum Willigisi et Gereonis archiepiscoporum</cei:narratio>
+                        <cei:dispositio> incitati iustis eius
+                            praecibus assensum praebuimus et eandem abbatiam cum omnibus iuste et
                             legaliter pertinentibus ad praefatam aecclesiam sancti Stephani, ubi
                             Piligrimus pontifex praeesse dinoscitur, donamus et imperiali uigore
                             perpetualiter roboramus eo uidelicet tenore, ut sepedictae aecclesiae

--- a/AT-StiAKr/KremsmuensterOSB/0975_VI_21.cei.xml
+++ b/AT-StiAKr/KremsmuensterOSB/0975_VI_21.cei.xml
@@ -67,13 +67,13 @@
                             ut easdem cartas in nostra nostrorumque fidelium praesentia legi
                             iuberemus. Cuius igitur petitionibus assensum praebentes coram fidelibus
                             nostris eas legi fecimus et interuentu dilecti ac fidelis nostri
-                            Willigisi archiepiscopi pium praedecessorum nostrorum morem sequentes
+                            Willigisi archiepiscopi</cei:narratio>
+                        <cei:dispositio> pium praedecessorum nostrorum morem sequentes
                             praedictam abbatiam cum omnibus ad eam iuste et legaliter pertinentibus,
                             hoc est ecclesiis, decimationibus, cellulis, curtis, agris, uineis,
                             nemoribus, pratis, pascuis, aquis, molendinis, exitibus et reditibus,
                             quaesitis et inquirendis et cum omnibus attinentiis ad iam dictam
-                            patauiensem sedem</cei:narratio>
-                        <cei:dispositio> iure imperiali tradimus et traditam confirmamus eo
+                            patauiensem sedem iure imperiali tradimus et traditam confirmamus eo
                             uidelicet tenore, ut eiusdem iam dictae Patauiensis aecclesiae rectores
                             perpetualiter eandem Abbatiam absque alicuius contradictione personae
                             teneant atque possideant.</cei:dispositio>

--- a/AT-StiAKr/KremsmuensterOSB/1052_VII_20.cei.xml
+++ b/AT-StiAKr/KremsmuensterOSB/1052_VII_20.cei.xml
@@ -68,9 +68,9 @@
                             regum aut imperatorum munificentia aecclesiae contulisset suae et idem
                             renouationis nostrae auctoritas roboraret. Eius nos iustae petitioni non
                             solum fidelis seruitii sui assiduitate commoniti sed et contectalis
-                            nostrae Agnetis imperatricis augustae precibus sollicitati pivm
-                            assensum</cei:narratio>
-                        <cei:dispositio> praebuimus et curtes, aecclesias, uillas et omnia praedia
+                            nostrae Agnetis imperatricis augustae</cei:narratio>
+                        <cei:dispositio> precibus sollicitati pivm
+                            assensum praebuimus et curtes, aecclesias, uillas et omnia praedia
                             cum suis pertinentiis a regibus uel imperatoribus aut ab aliis
                             religiosis uiris uel feminis sanctae patauiensi aecclesiae tradita,
                             insuper etiam specialiter abbatias Chremisimvnistivri, Matiseo cum

--- a/AT-StiAKr/KremsmuensterOSB/1063_X_25.cei.xml
+++ b/AT-StiAKr/KremsmuensterOSB/1063_X_25.cei.xml
@@ -69,8 +69,9 @@
                             renouationis nostrae auetoritas roboraret. Eius nos iuste petitioni non
                             solum fidelis seruitii sui assiduitate commoniti, Sed et dilecti nostri
                             magistri ANNONJS coloniensis archiepiscopi caeterorumque fidelium
-                            nostrorum precibus sollicitati pium assensum</cei:narratio>
-                        <cei:dispositio> praebuimus et curtes, aecclesias, villas et omnia praedia
+                            nostrorum</cei:narratio>
+                        <cei:dispositio> precibus sollicitati pium assensum praebuimus et curtes,
+							aecclesias, villas et omnia praedia
                             cum suis pertinentiis a regibus uel imperatoribus aut ab aliis
                             religiosis viris uel feminis sanctae Patauiensi aeeclesiae tradita,
                             Insuper etiam specialiter abbatias Chremisimvnistivri, Matiseo cum

--- a/AT-StiAL/LambachOSB/1061_II_18.1.cei.xml
+++ b/AT-StiAL/LambachOSB/1061_II_18.1.cei.xml
@@ -77,7 +77,8 @@
                             futuris quam praesentibus,</cei:publicatio>
                         <cei:narratio> qualiter nos ob interuentum dilectissime genitricis nostre
                             Agnetis auguste et ob peticionem fidelis nostri Adalberonis
-                            wirziburgensis episcopi bannum rnercati in loco Wels et theloneum in
+                            wirziburgensis episcopi</cei:narratio>
+                        <cei:dispositio> bannum rnercati in loco Wels et theloneum in
                             lambach et insuper bannum piscationis de superiori casu Trunae et in
                             agra ab asintal usque ad ea loca, ad que prediorum suorum termini
                             pertingunt, et ab asintal sursum conmunem utilitatem usque ad portum
@@ -88,8 +89,7 @@
                             suus Amoldus et frater suus marchio Gotefridus et ad ultimum idem
                             episcopus Adelbero eundem bannum habuerunt, aecclesiae in lambach, que
                             in honore sanctae Mariae et sancti Kyliani sociorumque eius constructa
-                            est, </cei:narratio>
-                        <cei:dispositio>cum omni utilitate, que ullo modo inde prouenire potest
+                            est, cum omni utilitate, que ullo modo inde prouenire potest
                             legitime, annuimus, potestatiue confirmamus et perpetuo in proprium
                             dedimus atque tradidimus ea uidelicet ratione, ut nullus in predictis
                             locis aut mercatum destruere aut theloneum impedire aut piscari aut

--- a/AT-StiAL/LambachOSB/1162_II_26.cei.xml
+++ b/AT-StiAL/LambachOSB/1162_II_26.cei.xml
@@ -93,9 +93,9 @@
                             tradidit ea uidelicet ratione, ut nullus in predictis locis aut mercatum
                             destruere aut theloneum impedire aut piscari aut noualia facere aut
                             domos edificare aut uenari sine consensu et uoluntate abbatis in lambach
-                            presumat. Igitur sicut hec ex antiquo regum et pontificum concessione
-                            hucusque durauerunt, </cei:narratio>
-                        <cei:dispositio>ita nos auctoritate omnipotentis dei et nostra potestate
+                            presumat.</cei:narratio>
+                        <cei:dispositio> Igitur sicut hec ex antiquo regum et pontificum concessione
+                            hucusque durauerunt, ita nos auctoritate omnipotentis dei et nostra potestate
                             permansura perpetualiter sancimus una cum theloneo, quod fidelissimvs
                             noster dominus heinricus episcopus in curia nostra coram principibus
                             iudiciario iure obtinuit,</cei:dispositio>

--- a/AT-StiAR/ReichensbergCanReg/1162_IV_04.cei.xml
+++ b/AT-StiAR/ReichensbergCanReg/1162_IV_04.cei.xml
@@ -78,13 +78,13 @@
                         <cei:narratio> quod nos benigno assensu annuentes piis et iustis
                             postulacionibus tuis, Gerhohe Richerspergensis preposite, interuentu
                             fidelium nostrorum, videlicet Eberhardi salzburgensis archiepiscopi et
-                            Eberhardi babenbergensis et Hartmanni brixinensis episcoporum ipsum
+                            Eberhardi babenbergensis et Hartmanni brixinensis episcoporum</cei:narratio>
+                        <cei:dispositio> ipsum
                             Richerspergense cenobium canonicorum regularium in comitatu Berthodi
                             comitis de andehs iuxta fluuium Enum situm in pago, quem transit fluuius
                             antesin, a quodam nobili uiro wernhero fundatvm et ecclesie salzburgensi
                             iure proprietatis collatum, salua in omnibus archiepiscopi
-                            salzburgensis, que prelibata est, iurisdictione,</cei:narratio>
-                        <cei:dispositio> nos in nostre imperialis maiestatis et omnium successorum
+                            salzburgensis, que prelibata est, iurisdictione, nos in nostre imperialis maiestatis et omnium successorum
                             nostrorum regum et imperatorvm tutelam suscepimus statuentes et firmiter
                             precipientes secundum antiquam et primitiuam illius loci libertatem ab
                             ipso fundatore collatam et priuilegiis uenerabilium archiepiscoporum

--- a/AT-StiASF/StFlorianCanReg/1109_XI_04.cei.xml
+++ b/AT-StiASF/StFlorianCanReg/1109_XI_04.cei.xml
@@ -105,11 +105,11 @@
                             constituit et omnia sua allodia tam hereditaria quam suo labore iuste
                             conquisita ad deo seruiendum contulit cum ecclesia, quam ipsemet
                             propriis bonis edificauit in honore sancte Marie sancto Floriano in
-                            loco, qui Floriani domus appellatur. Nos autem eiusdem deuoto rogatu et
+                            loco, qui Floriani domus appellatur.</cei:narratio>
+                        <cei:dispositio> Nos autem eiusdem deuoto rogatu et
                             licentia eadem allodia inter Bosenbac et Ebresbac usque ad terminos
                             boemie et predium, quod dicitur cella ad movhile, eidem supradicte
-                            ecelesie</cei:narratio>
-                        <cei:dispositio> per hanc preceptalem paginam regia consuetudine habenda
+                            ecelesie per hanc preceptalem paginam regia consuetudine habenda
                             perpetuo cum Omnibus eorum pertinentiis coricessimus atque firmauimus.
                             Videlicet familiis utriusque sexus, terris cultis et incultis, areis,
                             prediis, uinetis, pratis, riuis, pascuis, siluis, uenationibus, aquis

--- a/AT-StiASF/StFlorianCanReg/1125_XI_20.cei.xml
+++ b/AT-StiASF/StFlorianCanReg/1125_XI_20.cei.xml
@@ -103,12 +103,12 @@
                             salzeburgensis chovnradi, ratisponensis episcopi hartwigi, patauiensis
                             reginmarii, wormatiensis bucconis, babinbergensis ottonis, curiensis
                             chovnradi, ducis carinthie engilberti, palatini ottonis et gotefridi,
-                            comitis beringarii, marchionis dietpaldi aliorumque principum eidem
+                            comitis beringarii, marchionis dietpaldi aliorumque principum</cei:narratio>
+                        <cei:dispositio> eidem
                             monasterio Sancti Floriani predicta predia regia liberalitate donamus et
-                            tam ista quam alia eidem ecclesie</cei:narratio>
-                        <cei:dispositio> iuste et legaliter collata presentis decreti pagina
-                            firmamus et ut a nullo unquam diripiantur uel auferantur, regio ex more
-                            banno prohibemus et interdicimus.</cei:dispositio>
+                            tam ista quam alia eidem ecclesie iuste et legaliter collata presentis decreti pagina
+                            firmamus</cei:dispositio><cei:sanctio> et ut a nullo unquam diripiantur uel auferantur, regio ex more
+                            banno prohibemus et interdicimus.</cei:sanctio>
                         <cei:corroboratio> Quod ut inconuulsum ratumque apud posteros omni euo
                             permaneat, manu nostra firmauimus et sigilli nostri impressione
                             signauimus.</cei:corroboratio>

--- a/AT-StiASF/StFlorianCanReg/1142.1.cei.xml
+++ b/AT-StiASF/StFlorianCanReg/1142.1.cei.xml
@@ -74,17 +74,17 @@
                         <cei:arenga> Sicut diuina preordinante clementia ceteris mortalibus
                             quodammodo supereminemus, sic etiam uniuersas ecclesias et
                             ecclesiasticas personas diligere, fouere et ab iniquorum infestionibus
-                            (sic) defensare regali potentia a deo nobis commissa
-                            debemus.</cei:arenga>
+                            (sic) defensare regali potentia a deo nobis commissa debemus.</cei:arenga>
                         <cei:publicatio> Eapropter omnibus christi nostrisque fidelibus tam futuris
                             quam presentibus notum esse uolumus,</cei:publicatio>
                         <cei:narratio> qualiter nos ob regni nostri firmam stabilitatem et anime
                             nostre nostrorumque parentum perpetuam salutem, interuentu quoque et
-                            petitione dilecte coniugis nostre Gertrvdis regine ecclesiam sancti
+                            petitione dilecte coniugis nostre Gertrvdis regine</cei:narratio>
+                        <cei:dispositio> ecclesiam sancti
                             Floriani in Windeberge (sic) cum omnibus prediis et possessionibus suis,
                             que uel liberalitate regum seu donatione principum aut elemosina
-                            pauperum eidem ecclesie collata sunt,</cei:narratio>
-                        <cei:dispositio> in tutelam regie defensionis suscepimus. Nominatim autem
+                            pauperum eidem ecclesie collata sunt, in tutelam regie defensionis
+							suscepimus. Nominatim autem
                             omnia predia et possessiones, quas a capite Eberspach usque ad fines
                             boemie tam in longitudine quam in latitudine eadem ecclesia possedisse
                             cognoscitur, et a termino Aposenbach (sic) usque in uiam, que dicitur

--- a/AT-StiASF/StFlorianCanReg/1212_V_21.cei.xml
+++ b/AT-StiASF/StFlorianCanReg/1212_V_21.cei.xml
@@ -86,8 +86,7 @@
                             ecclesiam, que domus sancti floriani uocatur, pro spe eterne
                             retributionis in specialem defensionem nostram recepimus omnia iura sua
                             illi confirmantes et cuncta beneficia, que prefatus Dux et antecessores
-                            sui eidem Ecclesie contulerunt, auctoritate nostra
-                            corroborantes.</cei:arenga>
+                            sui eidem Ecclesie contulerunt, auctoritate nostra corroborantes.</cei:arenga>
                         <cei:publicatio> Omnibus ergo christi fidelibus presentis pagine inspectione
                             innotescere uolumus,</cei:publicatio>
                         <cei:narratio> quod prefata Ecclesia per prouidenciam iam dicti principis
@@ -104,12 +103,12 @@
                             in recompensacionem resignati iuris pheudali iure denuo inuestiret et
                             hec omnia presente Herbordo fratre prefati Ortolfi cum auxilio Ducis et
                             consensu tu<cei:sup>o</cei:sup>maduocati sub ydoneis testibus et debita
-                            sollempnitate adhibita sunt tractata. Nos itaque pro misericordia dei
+                            sollempnitate adhibita sunt tractata.</cei:narratio>
+                        <cei:dispositio> Nos itaque pro misericordia dei
                             promerenda totam istius facti seriem ratam habentes sepedictam Ecclesiam
                             sancti floriani cum hominibus et prediis suis cultis et incultis,
                             quesitis et inquisitis, habitis et habendis, cum pratis et
-                            pascuis,</cei:narratio>
-                        <cei:dispositio> cum uenacionibus et piscacionibus ab omni iure et
+                            pascuis, cum uenacionibus et piscacionibus ab omni iure et
                             obnoxietate secularis iudicii Imperiali auctoritate eximentes absoluimus
                             et liberam esse statuimus. Decernimus igitur, ut ab hac die nostre
                             constitucionis in antea nulli umquam secularium iudicum liceat alicuius

--- a/CH-StiASG/StiAPfae/0000.10.cei.xml
+++ b/CH-StiASG/StiAPfae/0000.10.cei.xml
@@ -111,10 +111,10 @@
                                 Cho<cei:sup>v</cei:sup>nradi nec non et beatae memoriae patris
                             nostri Heinrici imperatoris augusti, in quibus continebatur, ut praefati
                             monachi regiae vel imperialis defensionem tuitionis super res ad idem
-                            monasterium pertinentes habere debuissent. Quorum nos petitioni pro
-                            aeterna memoria patris coniugisque nostrae Berhthę * ipsos monachos et
-                            res ad prefatum monasterium pertinentes</cei:narratio>
-                        <cei:dispositio> per hoc regale praeceptum in nostrum mundiburdium et
+                            monasterium pertinentes habere debuissent.</cei:narratio>
+                        <cei:dispositio> Quorum nos petitioni pro aeterna memoria patris coniugisque
+							nostrae Berhthę * ipsos monachos et res ad prefatum monasterium pertinentes
+							per hoc regale praeceptum in nostrum mundiburdium et
                             tuitionem suscepimus, eo quoque tenore ut nullus publicus iudex dux
                             comes vel episcopus aut quislibet iudiciaria potestate constitutus
                             aliquam super eos in rebus vel in familiis eorum exerceat potestatem

--- a/CH-StiASG/StiAPfae/0000.294.cei.xml
+++ b/CH-StiASG/StiAPfae/0000.294.cei.xml
@@ -121,10 +121,10 @@
                         Heinrici<cei:sup>a)</cei:sup> patris nostri<cei:sup>d)</cei:sup> *
                     imperatoris augusti, in quibus continebatur, ut prefati monachi regię vel
                     imperialis defensionem tuitionis super res ad idem monasterium pertinentes
-                    habere debuissent. Quorum nos petitioni pro eterna memoria patris coniugisque
+                    habere debuissent.</cei:narratio>
+                        <cei:dispositio> Quorum nos petitioni pro eterna memoria patris coniugisque
                     nostrę Mathilde<cei:sup>a)</cei:sup> ipsos monachos et res ad prefatum
-                            monasterium pertinentes</cei:narratio>
-                        <cei:dispositio> per hoc regale preceptum in nostrum mundiburdium et
+                            monasterium pertinentes per hoc regale preceptum in nostrum mundiburdium et
                     tuitionem suscepimus, eo quoque tenore ut nullus publicus iudex dux comes vel
                     episcopus aut quilibet iudiciaria potestate constitutus aliquam super eos in
                     rebus vel in familiis eorum exerceat potestatem intus vel foris, sed eiusdem

--- a/CH-StiASG/StiAPfae/0000.32.cei.xml
+++ b/CH-StiASG/StiAPfae/0000.32.cei.xml
@@ -112,13 +112,14 @@
                             privilegia antecessorum nostrorum regum, * Karoli<cei:sup>2</cei:sup> *
                             videlicet et * Ludouuici<cei:sup>3</cei:sup> *, deprecantes nostram
                             clementiam ut nostre auctoritatis munimine ea renovaremus ac firmaremus
-                            electionemque illis concederemus. Quorum petitionem benigno ob amorem
+                            electionemque illis concederemus.</cei:narratio>
+                        <cei:dispositio> Quorum petitionem benigno ob amorem
                             domini nostri Iesu Christi * nostręque mercedis
                                 aucmentum<cei:sup>d)</cei:sup> suscipientes continuo, omnibus regni
                             nostri principibus episcopis abbatibus comitibus diiudicantibus atque
                             nostrę fidelitati consiliantibus, abbatem virum venerabilem quem inter
-                            eos eligerunt, Erembreht<cei:sup>4</cei:sup> nomine</cei:narratio>
-                        <cei:dispositio> constituimus et presens iussimus<cei:sup>e)</cei:sup> inde
+                            eos eligerunt, Erembreht<cei:sup>4</cei:sup> nomine constituimus et
+							presens iussimus<cei:sup>e)</cei:sup> inde
                             hoc munitatis<cei:sup>f)</cei:sup> nostrę privilegium conscribi per quod
                             volumus firmiterque iubemus, ut amodo ac deinceps omni tempore
                             firmissimam teneant potestatem quemcumque inter eos abbatem voluerint

--- a/CH-StiASG/StiAPfae/0000.363.cei.xml
+++ b/CH-StiASG/StiAPfae/0000.363.cei.xml
@@ -123,9 +123,9 @@
                             trium Ottonum, Heinrici secundi, Chunradi nec non Heinrici tercii et
                             Heinrici quarti, in quibus continebatur, ut prefati monachi regię vel
                             imperialis defensionem tuitionis super res ad idem monasterium
-                            pertinentes habere debeant. Quorum nos petitioni pro ęterna
-                            remuneratione annuentes monachos et res ad ipsos pertinentes * </cei:narratio>
-                        <cei:dispositio>in nostrum mundiburdium * suscepimus, eo * tenore ut nullus
+                            pertinentes habere debeant.</cei:narratio>
+                        <cei:dispositio> Quorum nos petitioni pro ęterna remuneratione annuentes monachos
+						et res ad ipsos pertinentes * in nostrum mundiburdium * suscepimus, eo * tenore ut nullus
                             * iudex dux comes * episcopus vel quilibet * in eis vel in eorum rebus
                             aliquam exerceat potestatem *, sed eiusdem monasterii prefatus abbas *
                             eiusque successores ad monachorum usus * potestative teneant atque

--- a/CH-StiASG/StiAPfae/0000.399.cei.xml
+++ b/CH-StiASG/StiAPfae/0000.399.cei.xml
@@ -99,8 +99,9 @@
                             idem monasterium * pertinentes habere debuissent. Quorum nos petitioni
                             ob amorem Christi et ob interventum dilectae coniugis nostrae Gislae
                             imperatricis augustae et amantissimę<cei:sup>e)</cei:sup> nostrae prolis
-                            Heinrici regis ipsos monachos et res ad prefatum monasterium pertinentes </cei:narratio>
-                        <cei:dispositio>per hoc imperiale preceptum in nostrum mundiburdium et
+                            Heinrici regis</cei:narratio>
+                        <cei:dispositio> ipsos monachos et res ad prefatum monasterium pertinentes
+							per hoc imperiale preceptum in nostrum mundiburdium et
                             tuitionem suscepimus, eo quoque tenore ut nullus publicus iudex dux *
                             comes vel episcopus vel quislibet iudiciaria potestate constitutus
                             aliquam super eos in rebus vel in familiis eorum exerceat potestatem

--- a/CH-StiASG/StiAPfae/0000.406.cei.xml
+++ b/CH-StiASG/StiAPfae/0000.406.cei.xml
@@ -106,16 +106,16 @@
                             antecessorum nostrorum, videlicet regum ac imperatorum Karoli, Ludovuici
                             nostrique genitoris Ottonis ceterorumque afferentes, in quibus
                             electionem sibi abbatem eligendum ab ipsa
-                                congregatione<cei:sup>b)</cei:sup> praefati monasterii
-                                affirmatum<cei:sup>c)</cei:sup> invenimus. Nos vero abbatiam cuidam
+                            congregatione<cei:sup>b)</cei:sup> praefati monasterii
+                            affirmatum<cei:sup>c)</cei:sup> invenimus.</cei:narratio>
+                        <cei:dispositio> Nos vero abbatiam cuidam
                             monacho Augensis coenobii nomine Alauuico<cei:sup>1</cei:sup>
                             commendatam habuimus quem idoneum et a nostris fidelibus probatum vitam
                             beati Benedicti monachos instruendum eligimus et abbatem posuimus.
                             Quorum tamen depraecationi ob amorem Christi futuraeque mercedis
                             augmentum benigne consentientes privilegii praeceptum electionisque
                             scriptum sicut ab antecessoribus nostris abbatem sibi ab ipso coenobio
-                            eligendum tenuerunt,</cei:narratio>
-                        <cei:dispositio> tali tenore concessimus ut post obitum ac discessum ipsius
+                            eligendum tenuerunt, tali tenore concessimus ut post obitum ac discessum ipsius
                             praelibati Alauuici abbatis firmiter teneant. Insuper eadem
                                 munificitia<cei:sup>c)</cei:sup> de rebus ad praefatum monasterium
                             pertinentibus concessimus ut nullus iudex publicus vel episcopus vel

--- a/CH-StiASG/StiAPfae/0000.470.cei.xml
+++ b/CH-StiASG/StiAPfae/0000.470.cei.xml
@@ -117,9 +117,9 @@
                             praecepta ac privilegia antecessorum nostrorum imperatorum Karoli ac
                             Lúdouuici in quibus continebatur, ut praefati monachi regiae vel
                             imperialis defensionem tuitionis super res eidem monasterio
-                            appertinentes habere debuissent, quorum nos petitioni ob amorem Christi
-                            futuraeque mercedis augmentum benigne assentientes</cei:narratio>
-                        <cei:dispositio> iussimus eis hoc praecepti nostri privilegium conscribi
+                            appertinentes habere debuissent,</cei:narratio>
+                        <cei:dispositio> quorum nos petitioni ob amorem Christi futuraeque mercedis
+						augmentum benigne assentientes iussimus eis hoc praecepti nostri privilegium conscribi
                             super res ad praefatum monasterium pertinentes. Idcirco volumus
                             firmiterque imperamus, ut nullus iudex publicus vel episcopus vel comes
                             vel quislibet iudiciaria potestate constitutus aliquam super eos in

--- a/CH-StiASG/StiAPfae/0000.472.cei.xml
+++ b/CH-StiASG/StiAPfae/0000.472.cei.xml
@@ -124,9 +124,9 @@
                             imperialis defensionem tuitionis super res ad idem monasterium
                             pertinentes habere debuissent. Quorum nos petitioni pro aeterna memoria
                             patris coniugisque nostrę Chunigundis simulque ob interventum dominę
-                            matris nostrę Gislae imperatricis * ipsos monachos et res ad prefatum
-                            monasterium pertinentes </cei:narratio>
-                        <cei:dispositio>per hoc regale preceptum in nostrum mundiburdium et
+                            matris nostrę Gislae imperatricis *</cei:narratio>
+                        <cei:dispositio> ipsos monachos et res ad prefatum
+                            monasterium pertinentes per hoc regale preceptum in nostrum mundiburdium et
                             tuitionem suscepimus, eo quoque tenore ut nullus publicus iudex dux
                             comes vel episcopus vel quislibet iudiciaria<cei:sup>c)</cei:sup>
                             potestate constitutus aliquam super eos in rebus vel in familiis eorum

--- a/CH-StiASG/Urkunden/A.1.A.13.cei.xml
+++ b/CH-StiASG/Urkunden/A.1.A.13.cei.xml
@@ -106,10 +106,10 @@
                             qualiter ipsi praescriptum coenobium et res omnes illuc aspicientes sub
                             regias et imperatorias emunitates suae tuitionis suscepissent. Pro rei
                             tamen firmitate || petiit celsitudinem nostram, ut nos denuo id ipsum
-                            faceremus. Eius petitioni pie assensum praebentes simulque
+                            faceremus.</cei:narratio>
+                        <cei:dispositio> Eius petitioni pie assensum praebentes simulque
                             praedecessorum nostrorum constituta sub immunitate sancti loci
-                            perpendentes</cei:narratio>
-                        <cei:dispositio> praecipimus et statuimus, ut praefatum monasterium ea
+                            perpendentes praecipimus et statuimus, ut praefatum monasterium ea
                             immunitate subsistat, sicut cartarum textus eidem loco conscriptarum
                             enuntiat, ut videlicet monachi in ipso monasterio convenientes secundum
                             regulam sancti Benedicti abbatis<cei:sup>a)</cei:sup> inter se eligendi

--- a/CH-StiASG/Urkunden/A.1.A_14.cei.xml
+++ b/CH-StiASG/Urkunden/A.1.A_14.cei.xml
@@ -96,10 +96,10 @@
                             qualiter ipsi prescriptum coenobium et res omnes illuc asspicientes sub
                             regias et imperatorias emunitates suae tuitionis suscepissent. Pro rei
                             tamen firmitate petiit celsitudinem nostram, ut nos denuo || id ipsum
-                            faceremus. Eius petitoni piae assensum prebentes simulque predecessorum
+                            faceremus.</cei:narratio>
+                        <cei:dispositio> Eius petitoni piae assensum prebentes simulque predecessorum
                             nostrorum constituta sub immunitate sancti loci
-                            perpendentes</cei:narratio>
-                        <cei:dispositio> precipimus et statuimus, ut prefatum monasterium ea
+                            perpendentes precipimus et statuimus, ut prefatum monasterium ea
                             immunitate subsistat, sicut cartarum textus eidem loco conscriptarum
                             enunciat, ut videlicet monachi in ipso monasterio convenientes secundum
                             regulam sancti Benedicti<cei:sup>b)</cei:sup> abbatem inter se eligendi

--- a/CH-StiASG/Urkunden/FF.3.S.1.cei.xml
+++ b/CH-StiASG/Urkunden/FF.3.S.1.cei.xml
@@ -94,12 +94,11 @@
                                 Houerdorf<cei:sup>7</cei:sup>, Burchardi fratris Burchardi
                                 marchionis<cei:sup>6</cei:sup>, Adelberti de
                                 Hortenburc<cei:sup>8</cei:sup>, Emelrici de
-                                Bosco<cei:sup>9</cei:sup> et aliorum, quos nominare longum est,
-                            quandam villam nomine Touwondorf<cei:sup>10</cei:sup> et ad hoc tantum,
+                                Bosco<cei:sup>9</cei:sup> et aliorum, quos nominare longum est,</cei:narratio>
+                        <cei:dispositio> quandam villam nomine Touwondorf<cei:sup>10</cei:sup> et ad hoc tantum,
                             ut XXX. mansus pleniter ibi habeantur<cei:sup>a)</cei:sup>, de illo
                             scilicet pre˛dio quod nobis dux Heinricus de Carinthia filius domini
-                                Marquardi<cei:sup>11</cei:sup> dedit, </cei:narratio>
-                        <cei:dispositio>e˛cclesie˛<cei:sup>b)</cei:sup> sancti Galli in proprium
+                                Marquardi<cei:sup>11</cei:sup> dedit, e˛cclesie˛<cei:sup>b)</cei:sup> sancti Galli in proprium
                             dedimus cum omnibus appendiciis, hoc est ministris mancipiis utriusque
                             sexus terris cultis et incultis areis pratis pascuis aquis aquarumque
                             decursibus piscationibus molis molendinis silvis venationibus viis et

--- a/DE-BayHStA/KURaitenhaslach/1034_05_08.cei.xml
+++ b/DE-BayHStA/KURaitenhaslach/1034_05_08.cei.xml
@@ -87,10 +87,10 @@
                         <cei:narratio> qualiter nos ob interventum ac peticionem dilecte coniugis
                             nostre Gisile, imperatricis videlicet auguste et amantissime nostre,
                             prolis Haeinrici regis, necnon et Pilgrimi Coloniensis archiepiscopi
-                            venerandi quoddam nostri iuris predium, id est unum nobilis viri mansum
+                            venerandi</cei:narratio>
+                        <cei:dispositio> quoddam nostri iuris predium, id est unum nobilis viri mansum
                             in loco Waltendorf dicto in pago Filisarihart et in comitatu Ottonis
-                            marchionis situm, cuidam nostri scilicet iuris servo Pabo dicto </cei:narratio>
-                        <cei:dispositio>cum omni lege et utilitate ad idem predium pertinente in
+                            marchionis situm, cuidam nostri scilicet iuris servo Pabo dicto cum omni lege et utilitate ad idem predium pertinente in
                             proprium tradidimus, areis, edificiis, agris, campis, pratis, pascuis,
                             exitibus et reditibus, terris cultis et incultis, silvis, venationibus,
                             viis et inviis, aquis aquarumque decursibus, piscationibus, molis,

--- a/DE-BayHStA/KURaitenhaslach/1051_02_10.cei.xml
+++ b/DE-BayHStA/KURaitenhaslach/1051_02_10.cei.xml
@@ -114,12 +114,11 @@
                         <cei:narratio> qualiter nos ob interventum nostri thori ac regni consortis,
                             scilicet Agnetis imperatricis auguste, ceterorumque nostrorum fidelium
                             Chůnradi Bawariorum ducis et Nitgeri Frisingensis episcopi
-                                Gebehardique<cei:sup>a</cei:sup> Eichstetensis episcopi servienti
-                            nostro Rafoldo duos regales mansos<cei:sup>b</cei:sup> in villa Nahtstal
-                            in pago Zidalarego<cei:sup>v</cei:sup>we in comitatu
-                                O<cei:sup>v</cei:sup>zzonis comitis sitos<cei:sup>c</cei:sup>
-                        </cei:narratio>
-                        <cei:dispositio>cum omnibus pertinentiis suis in proprium tradidimus areis,
+                            Gebehardique<cei:sup>a</cei:sup> Eichstetensis episcopi</cei:narratio>
+                        <cei:dispositio> servienti nostro Rafoldo duos regales mansos<cei:sup>b</cei:sup>
+							in villa Nahtstal in pago Zidalarego<cei:sup>v</cei:sup>we in comitatu
+                            O<cei:sup>v</cei:sup>zzonis comitis sitos<cei:sup>c</cei:sup>
+							cum omnibus pertinentiis suis in proprium tradidimus areis,
                             edificiis, agiis, pratis, campis, pascuis, terris cultis et incultis,
                             silvis, venationibus, saginationibus, lignorum incisionibus, aquis
                             aquarumque decursibus, molis, molendinis, piscationibus, viis et inviis,

--- a/DE-BayHStA/KURaitenhaslach/1079_10_24.cei.xml
+++ b/DE-BayHStA/KURaitenhaslach/1079_10_24.cei.xml
@@ -111,15 +111,15 @@
                             quam presentibus,</cei:publicatio>
                         <cei:narratio> qualiter nos ob interventum Berhte et regni et thori socie ac
                             dilecti filii nostri Chůnradi, Haeinrici<cei:sup>a</cei:sup> patriarche,
-                            Megenwardi Frisingensis episcopi ceterorumque fidelium nostrorum cuidam
-                            servienti nostro nomine Rafold mansum, id est regalem, situm in villa
+                            Megenwardi Frisingensis episcopi ceterorumque fidelium nostrorum</cei:narratio>
+                        <cei:dispositio> cuidam servienti nostro nomine Rafold mansum, id est regalem, situm in villa
                             Walde in pago Isinigowe in comitatu O<cei:sup>v</cei:sup>dalrici cum
                             omnibus appenditiis, areis<cei:sup>b</cei:sup>, edificiis, terris cultis
                             et incultis, viis et inviis, pratis, pascuis, campis, silvis,
                             venationibus, aquis aquarumque decursibus, molis, molendinis,
                             piscationibus, exitibus et reditibus, quesitis et inquirendis ac cum
-                            omni utilitate, que ullo modo inde provenire poterit,</cei:narratio>
-                        <cei:dispositio> in proprium tradendo firmavimus, firmando tradidimus;
+                            omni utilitate, que ullo modo inde provenire poterit, in proprium
+							tradendo firmavimus, firmando tradidimus;
                             insuper ancillam unam nomine Adelhait<cei:sup>c</cei:sup> sibi dedimus
                             ea autem conditione, ut idem Rafold deinceps liberam potestatem habeat
                             eundem mansum possidendi, posteris relinquendi vel dandi cui voluerit,

--- a/FreisBm/0965_IV_03.cei.xml
+++ b/FreisBm/0965_IV_03.cei.xml
@@ -68,9 +68,9 @@
                         <cei:publicatio> Nouerint omnes fideles nostri praesentes scilicet et
                             futuri, </cei:publicatio>
                         <cei:narratio>qualiter nos per interuentum dilecte ducis (!) domineque
-                            Judite, nee non oratu riobis satis cari episcopi Abrabe cuidam suo
-                            vasallo Negomir nueupato (!)</cei:narratio>
-                        <cei:dispositio> donavimus talem proprietatem, qualem nos visi sumus habere
+                            Judite, nee non oratu riobis satis cari episcopi Abrabe</cei:narratio>
+                        <cei:dispositio> cuidam suo
+                            vasallo Negomir nueupato (!) donavimus talem proprietatem, qualem nos visi sumus habere
                             ad Vuirzsosah in partibus Carantanie in comitatu Hartuuigi comitis qui
                             et ipse inibi vualtpoto dicitur, ac in decania Vuolframmi decani,
                             aeternaliter in proprietatem habendum cum curtibus et edifieiis, pratis,

--- a/FreisBm/0972_V_28.cei.xml
+++ b/FreisBm/0972_V_28.cei.xml
@@ -57,7 +57,8 @@
                         <cei:publicatio>Nouerint omnes nostri fideles presentes scilicet atque
                             futuri,</cei:publicatio>
                         <cei:narratio> qualiter nos per interuentum dilecte coniugis nostre
-                            Adalheide nee non equiuoci nostri (!) quasdam res nostri iuris sitas in
+                            Adalheide nee non equiuoci nostri (!)</cei:narratio>
+                        <cei:dispositio> quasdam res nostri iuris sitas in
                             comitatu Taruisiano haut longe a fluuio Uallatus<cei:sup>1</cei:sup> et
                             in loco qui dicitur Chunio, qui situs est prope litus Brente, qui fuit
                             Ysaac Judeotraditusa Wicberto, etin loco qui dicitur Piseatorus et
@@ -72,8 +73,7 @@
                             decursibus, piscationibus, molendinis, siluis et paludibus omnibusque
                             rebus iuste legitimeque ad eandem curtem respicientibus, quesitis et
                             inquirendis ad seruitium saneti Candidi ad Inticam in manus nobis satis
-                            cari episcopi Abraham appellati </cei:narratio>
-                        <cei:dispositio>ob remedium anime nostre tradidimus eo scilicet tenore, ut
+                            cari episcopi Abraham appellati ob remedium anime nostre tradidimus eo scilicet tenore, ut
                             isdem iam dictus episcopus usque ad obitum sui absque contradictione
                             omnium totum atque integrum teneat atque possideat, postea yero seruitio
                             saneti Candidi redintegratum perpetim inibi permansurum ad Inticam

--- a/FreisBm/0973_VI_30.cei.xml
+++ b/FreisBm/0973_VI_30.cei.xml
@@ -60,7 +60,8 @@
                         <cei:publicatio> Nouerit omnium industria fidelium nostrorum tarn presentium
                             quam futurorum,</cei:publicatio>
                         <cei:narratio> qualiter per interuentum dilecte matris nostre Adelheide et
-                            fidelis nostri uidelicet Heinrici ducis quasdam partes nostre
+                            fidelis nostri uidelicet Heinrici ducis</cei:narratio>
+                        <cei:dispositio> quasdam partes nostre
                             proprietatis sitas in ducatu prefati ducis et in comitatu Poponis
                             comitis quod Carniola uocatur et quod uulgo Creina marcha appellatur.
                             Est enim in ipso comitatu riuulüs paruus qui uocabulo Sclauorum Sabniza
@@ -72,8 +73,7 @@
                             deorsum usque ad ostium pretitulati riuuli Sabniza indeque sursum ad
                             caput uel exitum ipsius riuuli quicquid inter ipsa confluentia habuisse
                             uideamur, loca sie notninata Sabniza, Lonca, Susane, iterumque Celsah
-                            uel qualicumque uocabulo uocantur, </cei:narratio>
-                        <cei:dispositio>hoc totum in proprium cuidam nostro fideli nobisque satis
+                            uel qualicumque uocabulo uocantur, hoc totum in proprium cuidam nostro fideli nobisque satis
                             percaro episcopo Abraham uocitato donauimus cum omnibus rebus iure
                             legitime(que) ad pretitulata loca aspicientibus, cum curtilibus et
                             edifieiis, manieipiis utriusque sexus, si inibi nostri iuris

--- a/FreisBm/0973_XI_23.cei.xml
+++ b/FreisBm/0973_XI_23.cei.xml
@@ -75,8 +75,9 @@
                             scilicet et futurorum industria,</cei:publicatio>
                         <cei:narratio> qaliter (!) nos dignis et admodum honestis petitionibus
                             dilectissimae coniugis nostrae Theophanu nee non cari nepotis nostri
-                            Baioariorum ducis Heinrici suppliciter obsequendo rogati venerabili et
-                            totius religionis uiroAbrahae sanctae Frigisingensis aecclesiae praesuli
+                            Baioariorum ducis Heinrici</cei:narratio>
+                        <cei:dispositio> suppliciter obsequendo rogati venerabili et
+                            totius religionis uiro Abrahae sanctae Frigisingensis aecclesiae praesuli
                             nostrae familiaritati digne adiuneto quandam nostrae proprietatis partem
                             in regione vulgari vocabulo Chreine et in marcha et in comitatu Paponis
                             comitis sitam, id est ubi riuvlus Sabniza originem producere ineipit,
@@ -93,8 +94,7 @@
                             territorium et siluvla quae Szovrska Dubravua (dicitur), sub eadem
                             comprehensione teneatur et spatium quod iacet inter Primet et
                             Vuizilinesteti, per medium diuidatur et sie usque in praefatum riuvlum
-                            Sabniza, </cei:narratio>
-                        <cei:dispositio>nostraimperiali donauimus potentia in proprium et perpetuum
+                            Sabniza, nostraimperiali donauimus potentia in proprium et perpetuum
                             vsumconcessimus firmiterque cum terris eultis et incultis, pratis,
                             paseuis, siluis, aedifieiis, aquis aquarumue decursibus ipsoque iam
                             dicto foresto, uenationibus, piscationibus, molendinis, mobilibus et

--- a/FreisBm/0989_X_01.cei.xml
+++ b/FreisBm/0989_X_01.cei.xml
@@ -59,7 +59,8 @@
                             scilicet et futurorum industria,</cei:publicatio>
                         <cei:narratio> qualiter nos dignis et admodum honestis peticionibus dilecte
                             matris nostre Theopbanu, necnon cari nepotis nostri Karentinorum ducis
-                            Heinrici suppliciter rogati uenerabili viro Abrahe sancte Frisingensis
+                            Heinrici</cei:narratio>
+                        <cei:dispositio> suppliciter rogati uenerabili viro Abrahe sancte Frisingensis
                             ecclesie presuli nostre familiaritati digne adiuncto quandam nostrae
                             proprietatis partem in regione uulgari uocabulo Chreine et in marcha
                             ducis Heinrici et in comitatu Waltilonis comitis sitam, inde ubi riuulus
@@ -76,8 +77,7 @@
                             dum Zoura hostium facit in Zauam ac quiequid inde locorum inter illas
                             proprietates duas situm est, Abrahe uidelicet episcopi ac
                                 Vuernhardi<cei:sup>3</cei:sup> comitis, excepta proprietate
-                            Pribizlauui, </cei:narratio>
-                        <cei:dispositio>nostra regali traditione sibi donata hoc totum nobis
+                            Pribizlauui, nostra regali traditione sibi donata hoc totum nobis
                             pertinens Abrahe episcopo in proprietatem donare curauimvs a iuncta ripa
                             Zourae quantum extenditur unius iugeri longitudo, usque ad uadum quod
                             uulgo Stresoubrod uocant, ibique ultra eundem fluuium occidentem uersus

--- a/FreisBm/1002_XI_11.cei.xml
+++ b/FreisBm/1002_XI_11.cei.xml
@@ -61,11 +61,12 @@
                             futuri,</cei:publicatio>
                         <cei:narratio> qualiter nos ob interuentum dilecte nostre coniugis
                             Chunigunde regine fidelisque nostri Gotescalchi Frisingensis ecelesie
-                            antistitis quoddam predium Strasista uocatum et quiequid intra tres
+                            antistitis </cei:narratio>
+                        <cei:dispositio>quoddam predium Strasista uocatum et quiequid intra tres
                             fluuios Libniza, Sabum, Zoura in regione Carniola et in comitatu
                             Vualtilonis comitis nostri iuris situm est, super gremium sanete Marie
-                            seinper uirginis sanctique Corbiniani ibidem Frisinge </cei:narratio>
-                        <cei:dispositio>corporaliter quiescentis in proprium donauiinus cum omnibus
+                            seinper uirginis sanctique Corbiniani ibidem Frisinge corporaliter
+							quiescentis in proprium donauiinus cum omnibus
                             ad idem predium pertinentibus edifieiis, maneipiis, agris, pratis,
                             siluis, paseuis, aquis aquarumqne decursibus, molendinis, piscationibus,
                             exitibus et reditibus, zidaluvedon<cei:sup>1</cei:sup>. foresto,

--- a/FreisBm/1007_V_10.1.cei.xml
+++ b/FreisBm/1007_V_10.1.cei.xml
@@ -64,8 +64,8 @@
                             episcopi in cuius laribus eis que sancte Marie sanctique Corbiniani
                             erant, bonis pariter utentes paterno lenimine benigne nutriebamur, ac
                             pro requie pii presulis Gotescalchi iam defuncti et quia nostrutn
-                            fidelem Egilbertmn antistitem </cei:narratio>
-                        <cei:dispositio>de propria quasi camera ad tale dispendium superandum vix
+                            fidelem Egilbertmn </cei:narratio>
+                        <cei:dispositio> antistitem de propria quasi camera ad tale dispendium superandum vix
                             nostre assiduitati subtraximus, quoddam nostri iuris predium Chatsa
                             uulgo nominatum, in prouincia Karinthia situm cum familiis utriusque
                             sexus, cortiferis (!), edificiis, terris cultis et incultis, quesitis et

--- a/FreisBm/1033_V_07.cei.xml
+++ b/FreisBm/1033_V_07.cei.xml
@@ -84,7 +84,8 @@
                             nostrae ob interuentum et petitionem dilectae nostrae coniugis Gisilae
                             imperatricis augustae, necnon Heinrici regis filii nostri, ob iuge etiam
                             deuotumque seruitium fidelis nostri Egilberti Frisingensis
-                                aecclesiae<cei:sup>1</cei:sup> uenerabilis episcopi eidem presuli
+                                aecclesiae<cei:sup>1</cei:sup> uenerabilis episcopi</cei:narratio>
+                        <cei:dispositio> eidem presuli
                             suaeque aecclesiae<cei:sup>2</cei:sup> Frisingensi largiti sumus in
                             Orienti parte iuxta fluuium Urula uocatum in comitatu marchionis
                                 Adalberti<cei:sup>3</cei:sup> cum omni lege hobas regales duas quae
@@ -97,8 +98,7 @@
                             et inuiis, cultis et incolendis, quesitis (et) inquirendis, agris,
                             campis, pratis, siluis, uenationibus, aquis aquarumque decursibus,
                             molis, molendinis, piscationibus seu cum omnibus utilitatibus que˛ sic
-                            dici aut scribi possunt, easque</cei:narratio>
-                        <cei:dispositio> per hanc nostram imperialem paginam de nostro iure et
+                            dici aut scribi possunt, easque per hanc nostram imperialem paginam de nostro iure et
                             dominio in eius ius et dominium transfundimus et in proprium tradidimus
                             ea videlicet ratione, ut iam dictus presul suique successores liberam
                             deinceps potestatem habeant in usum aecclesiae<cei:sup>4</cei:sup>

--- a/FreisBm/1049_I_07.cei.xml
+++ b/FreisBm/1049_I_07.cei.xml
@@ -65,11 +65,11 @@
                         <cei:narratio> qualiter nos pro anime nostre felicitate et ante cessorum
                             nostrorum requie et ob interuentum nostri thori ac regni consortis
                             scilicet Agnetis imperatricis auguste et ob deuotam seruitutem nostri
-                            fidelis et dilecti Nitkeri Frisingensis episcopi ad altare sancte Marie
+                            fidelis et dilecti Nitkeri Frisingensis episcopi</cei:narratio>
+                        <cei:dispositio> ad altare sancte Marie
                             semper uirginis sanctique Corbiniani confessoris in monasterio Frisinga
                             tale predium quale Vlrich et Ascuuin in Ardack(er) in comitatu
-                            marchionis Adalberti trans fluuium Ensa habuerunt,</cei:narratio>
-                        <cei:dispositio> iure gentium nostre potestati dicatum tradidimus cum
+                            marchionis Adalberti trans fluuium Ensa habuerunt, iure gentium nostre potestati dicatum tradidimus cum
                             omnibus suis pertinentiis, cum mancipiis scilicet utriusque sexus,
                             areis, edificiis, agris, pratis, campis, pascuis, terris cultis et
                             incultis, siluis, uenationibus, aquis aquarumque decursibus, molis,

--- a/FreisBm/1055_XII_10.cei.xml
+++ b/FreisBm/1055_XII_10.cei.xml
@@ -91,14 +91,13 @@
                             eterna tabernacula possint recipere.</cei:arenga>
                         <cei:publicatio> Propterea notum sit omnibus Christi nostrique fidelibus tam
                             futuris quam presentibus,</cei:publicatio>
-                        <cei:narratio> quia illis nostris fratribus in memoriam nostri et regni
+                        <cei:dispositio>quia illis nostris fratribus in memoriam nostri et regni
                             thorique nostri consortis Agnetis imperatricis, necnon dilectissimi
                             filii nostri Heinrici regis quarti, quicquit Otto dare destinauit, cum
                             omnibus suis appenditiis hoc est utriusque sexus mancipiis, areis,
                             edificiis, agris, pratis, pascuis, terris cultis et incultis, uineis,
                             aquis aquarumque decursibus, molis, molendinis, piscationibus, siluis,
-                            uenacionibus, exitibus et reditibus, </cei:narratio>
-                        <cei:dispositio>quesitis et inquirendis cum omni utilitate quae ullomodo
+                            uenacionibus, exitibus et reditibus, quesitis et inquirendis cum omni utilitate quae ullomodo
                             inde poterit prouenire, in proprium damus.</cei:dispositio>
                         <cei:corroboratio> Et ut hec nostre imperigalis (!) traditionis auctoritas
                             stabilis et inconuulsa omni euo permaneat, hanc cartam inde conscriptam

--- a/FreisBm/1067_III_05.cei.xml
+++ b/FreisBm/1067_III_05.cei.xml
@@ -77,15 +77,15 @@
                             interuentum Berthe reginae regni thorique nostri consortis dilectissimae
                             instinctu quoque Epponis Niwenburgensis episcopi, Ekkiberti marchionis,
                             Odalrici marchionis, nec non ob fidele meritum Ellenhardi eiusdem sedis
-                            episcopi, hasuillas Cubida, Lovnca, Ozpe, Razari, Trvscvlo, Steina,
+                            episcopi,</cei:narratio>
+                        <cei:dispositio> hasuillas Cubida, Lovnca, Ozpe, Razari, Trvscvlo, Steina,
                             sancte Petre in pago Istria in marcha Odalrici marchionis sitas cum
                             omnibus appendiciis suis hoc est utriusque sexus mancipiis, uineis,
                             agris, pratis, campis, pascuis, siluis, uenationibus, forestis,
                             forestariis, ecclesiis, areis edificiis, terris cultis et incultis,
                             aquis aquarumue decursibus, molis, molendinis, piscationibus, exitibus
                             et reditibus, uiis et inuiis, merkatis, theloneis, monetis, quaesitis et
-                            inquirendis </cei:narratio>
-                        <cei:dispositio>omnique utilitate iu proprium dedimus, confirmauimus,
+                            inquirendis omnique utilitate iu proprium dedimus, confirmauimus,
                             perpetuo iure obtinendum concessimus, ea uidelicet ratione, ut nullus
                             successorum nostrorum imperator siue rex, dux, marchio, comes aut alia
                             maior uel minor persona iudicialis haec data prefatae ecclesiae auferre,

--- a/FreisBm/1074_XI_26.cei.xml
+++ b/FreisBm/1074_XI_26.cei.xml
@@ -72,7 +72,7 @@
                     <cei:context>
                         <cei:publicatio>omnibus Christi nostrique fidelibus tam futuris quam
                             presentibus notum esse uolumus,</cei:publicatio>
-                        <cei:narratio> qualiter nos in presentia principum nostrorum Gebehardi
+                        <cei:dispositio>qualiter nos in presentia principum nostrorum Gebehardi
                             Salzburgensis archiepiscopi, Ottonis Ratisponensis, Uvillehelmi
                             Traiectensis episcoporum, Uvelph ducis Bauuariorum ce˛terorumque
                             fidelium nostrorum ex predio quod Salamon rex Ungarorum nostre potestati
@@ -85,8 +85,7 @@
                             aedificiis, pratis, pascuis, uineis, terris cultis et incultis, uiis et
                             inuiis, aquis aquarumque decursibus, molis, molendinis, piscationibus,
                             exitibus et reditibus, quaesitis et inquirendis, exceptis uenationibus
-                            et uviltbanno in Litahaberge, </cei:narratio>
-                        <cei:dispositio>aliis autem omnibus utilitatibus in proprium tradendo
+                            et uviltbanno in Litahaberge, aliis autem omnibus utilitatibus in proprium tradendo
                             firmauimus [et] firmando tradidimus, ea uidelicet conditione qua cum
                             omnibus ex prefato predio donatis convenimus, ut idem Frisingensis
                             episcopus Ellenhardus suique successores in quolibet castello

--- a/FreisBm/1189_V_18.cei.xml
+++ b/FreisBm/1189_V_18.cei.xml
@@ -63,7 +63,7 @@
                             euanescant. </cei:arenga>
                         <cei:publicatio>Vnde nouerint tam presentes quam postfuturi fideles
                             Christi,</cei:publicatio>
-                        <cei:narratio> quod cum dilecti nostri consanguinei dux videlicet Austrie
+                        <cei:dispositio>quod cum dilecti nostri consanguinei dux videlicet Austrie
                             Leopaldus eiusque filius Fridericus nomine omnem maiestati nostre
                             resignasse(n)t iusticiam, quam per dominicalia Frisingensis episcopii
                             quondam ab imperio possederant in Austria, id est marhrelit et
@@ -71,8 +71,7 @@
                             in officio Enzinstorf et Alarn, quam etiam in Holenburch et Ebersdorf,
                             nos ob instantem eorundem peticionem atque dilecti nobis ac venerabilis
                             episcopi Ottonis amorem ad hoc sumus inducti, quod predictam iusticiam
-                            nobis resignatam ecclesie beate Virginis sanctique Corbiniani Frisinge </cei:narratio>
-                        <cei:dispositio>donacione regali tradidimus, proinde sperantes premio nos
+                            nobis resignatam ecclesie beate Virginis sanctique Corbiniani Frisinge donacione regali tradidimus, proinde sperantes premio nos
                             eterne beatitudinis in futuro remunerari.</cei:dispositio>
                         <cei:corroboratio> Vt autem hec nostra traditio sine retractatione stabilis
                             et inconuulsa omni permaneat euo, hanc inde paginam conscribi ac

--- a/OOEUB/0977_X_05.1.cei.xml
+++ b/OOEUB/0977_X_05.1.cei.xml
@@ -67,15 +67,15 @@
                             exercitus nostri morosa sustentatione grauem intulimus iacturam, pro
                             diuino timore et aeternae retributionis indubia spe ac insuper
                             amantissimi fratruelis nostri Ottonis ducis nec non spectabilis
-                            liutbaldi marchionis petitionibus inducti quoddam nostrae potestatis
+                            liutbaldi marchionis petitionibus </cei:narratio>
+                        <cei:dispositio>inducti quoddam nostrae potestatis
                             praedium Anesapurch nuncupatum in pago trungouue in ripa anesi fluminis
                             in comitatu liutbaldi cum omnibus suis pertinentiis, sicut piae
                             recordationis noster patruus Heinricus et beatae memoriae episcopo
                             Adalberto in concambium recepit, Sanctae Lauriacensi aecclesiae, quae in
                             honore sancti Stephani sanctique laurentii martyrum foris murum
                             aedificata est, ubi antiquis etiam temporibus prima sedes episcopalis
-                            habebatur,</cei:narratio>
-                        <cei:dispositio> imperiali auctoritate in proprium tradimus atque
+                            habebatur, imperiali auctoritate in proprium tradimus atque
                             concedimus, Quin etiam decem regales hobas ab occidentali ripa praedicti
                             fluminis Anesi in quadam nostri juris uilla nomine Loracho cum mancipiis
                             utriusque sexus, quibus erant possessae, et cum omni integritate,

--- a/OOEUB/0993_I_27.cei.xml
+++ b/OOEUB/0993_I_27.cei.xml
@@ -63,12 +63,12 @@
                             episcopus ad nos uenit rogans et petens, ut omnia a regibus uel
                             imperatoribus aut ab aliis religiosis uiris uel feminis eidem aecclesiae
                             tradita nostrae auctoritatis donatione confirmaremus, sicut antecessores
-                            nostri reges et imperatores fecerunt. Cuius iustae peticioni pro animae
+                            nostri reges et imperatores fecerunt.</cei:narratio>
+                        <cei:dispositio> Cuius iustae peticioni pro animae
                             nostrae remedio pium assensum praebentes omnes curtes, abbacias,
                             aecclesias, uicos et uillas et alia praedia cum suis pertinentiis ab
                             aliquibus personis maioribus uel minoribus pro mercede aeternae
-                            retributionis praefatae aecclesiae tradita </cei:narratio>
-                        <cei:dispositio>hac nostrae praeceptionis auctoritate nouiter eidem
+                            retributionis praefatae aecclesiae tradita hac nostrae praeceptionis auctoritate nouiter eidem
                             aecclesiae donamus atque confirmamus Et insuper nominatiue abbaciam,
                             quae dicitur Chremisemuntstiuri, cum suis omnibus pertinentiis,
                             curtibus, uicis et uillis, aecclesiis et aliis utensilibus illuc rite

--- a/OOEUB/1005_XII_07.cei.xml
+++ b/OOEUB/1005_XII_07.cei.xml
@@ -67,11 +67,11 @@
                         <cei:publicatio>Quapropter generaliter omnium pateat
                             industrie,</cei:publicatio>
                         <cei:narratio> qualiter nos interveniente dilecta coniuge nostra Chunegunda
-                            videlicet regina quoddarn nostri iuris predium Slierbach dictum in
+                            videlicet regina</cei:narratio>
+                        <cei:dispositio> quoddarn nostri iuris predium Slierbach dictum in
                             comitatu Rapotonis situm, in pago vero Ouliupestale Juvavensi ecclesie,
                             ubi sanctus Roudbertus corporaliter requiescit, pro redemptione anime
-                            nostre dilecteque coniugis </cei:narratio>
-                        <cei:dispositio>per hoc regale testamentum donando firmamus cum omnibus
+                            nostre dilecteque coniugis per hoc regale testamentum donando firmamus cum omnibus
                             appendiciis et utilitatibus eidem predio adiacentibus, cum familia
                             utriusque sexus, cura areis, edificiis, terris, cultis et incultis,
                             viis, inviis, exitibus et reditibus, aquis aquarurave decursibus,

--- a/OOEUB/1007_XI_01.1.cei.xml
+++ b/OOEUB/1007_XI_01.1.cei.xml
@@ -81,7 +81,7 @@
                             salutaris;</cei:arenga>
                         <cei:publicatio> proinde nouerit omnium nostri fidelium tam praesens etas
                             quam et suecessura posteritas,</cei:publicatio>
-                        <cei:narratio> quia nos nostrae quendam proprietatis locura Matughof dictum
+                        <cei:dispositio>quia nos nostrae quendam proprietatis locura Matughof dictum
                             in pago Matuggouuue et in comitatu Gebehardi comitis situm ad eandem
                             supradictam episcopalem sedem Babenberc dictam vna cum omnibus eius
                             pertinentiis siue adherentiis, videlicet vicis, villis, aecclesiis,
@@ -89,8 +89,7 @@
                             inuiis, exitibus et reditibus, quaesitis uel inquirendis, siluis,
                             forestibus, saginis, venationibus, aquis, piseationibus, molis,
                             molendinis, rebus mobilibus et inmobilibus ac ceteris omnibus, quae rite
-                            scribi uel appellari possunt,</cei:narratio>
-                        <cei:dispositio> quoquolibet modo utilitatibus hac nostrae auctoritatis
+                            scribi uel appellari possunt, quoquolibet modo utilitatibus hac nostrae auctoritatis
                             praeceptali pagina, prout firmius possumus, donamus atque proprietamus
                             omnium contradictione remota Precipientes igitur, ut in deo dilectus
                             nobis sepe dictae sedis Eberhardus episcopus liberam dehinc habeat

--- a/OOEUB/1007_XI_01.cei.xml
+++ b/OOEUB/1007_XI_01.cei.xml
@@ -79,7 +79,7 @@
                             jugis pro omnibus ortodoxis hostia mactaretur salutaris.</cei:arenga>
                         <cei:publicatio> Proinde nouerit omnium nostri fidelium tarn presens etas
                             quam et successura posteritas,</cei:publicatio>
-                        <cei:narratio> quia nos nostrae proprietatis quendam locum Aterahof dictum
+                        <cei:dispositio>quia nos nostrae proprietatis quendam locum Aterahof dictum
                             in pago Ateragowi et in comitatu Gebehardi comitis situm ad eandem
                             episcopalem sedem Babenberc dictam vna cum omnibus eius pertinentiis
                             siue adherentiis, videlicet vicis, villis, aecclesiis, seruis et
@@ -87,8 +87,7 @@
                             exitibus et reditibus, quaesitis uel inquirendis, siluis, forestibus,
                             saginfs, venatonibus, aquis, piscationibus, molis, molendinis, rebus
                             mobilibus et inmobilibus ac ceteris rebus omnibus, quae rite dici uel
-                            scribi posunt,</cei:narratio>
-                        <cei:dispositio> utilitatibus hac nostrae auctoritatis preceptali pagina,
+                            scribi posunt, utilitatibus hac nostrae auctoritatis preceptali pagina,
                             prout firmissime possumus, donamus atque proprietamus omnium
                             contradictione remota. Precipientes igitur, ut nobis in deo dilectus
                             sepe dictae sedis Eberhardus episcopus liberam dehinc habeat potestatem

--- a/OOEUB/1018.cei.xml
+++ b/OOEUB/1018.cei.xml
@@ -94,12 +94,12 @@
                             sanctae romanae aecclesiae firmiter possideant. De contra uero dato
                             predio Antisina et eius pertinentiis se ulterius non intermittant
                             (intromittant). Igitur fidelium nostrorum communi consensu firmato
-                            concambio nouerit omnium dei nostrique fidelium uniuersitas, qualiter
+                            concambio nouerit omnium dei nostrique fidelium uniuersitas,</cei:narratio>
+                        <cei:dispositio> qualiter
                             tarn pro senioris et anteccessoris nostri Ottonis scilicet tercii
                             imperatoris quam pro nostro parentumque nostrorum remedio eundem sepe
                             dictum locum ad Stipendium canonicorum in coenobio sancti Petri
-                            sanctique Georgii Babenberc degentium</cei:narratio>
-                        <cei:dispositio> per hanc imperialem nostrae traditionis paginam concedimus,
+                            sanctique Georgii Babenberc degentium per hanc imperialem nostrae traditionis paginam concedimus,
                             donamus atque proprietamus cum omnibus eius pertinentiis et utilitatibus
                             omnium contradictione remota, Precipientes igitur, ut neque imperator
                             neque dux, neque episcopus neque comes neque magna uel parua persona

--- a/StPCanReg/0976_VII_22.cei.xml
+++ b/StPCanReg/0976_VII_22.cei.xml
@@ -98,10 +98,10 @@
                             petiit excellentiam nostram praedictus presul, ut morem parentum
                             sequentes eandem sedem cum omnibus sibi subiectis simili modo sub nostra
                             constitueremus defensione et inmunitatis tuitione.<cei:sup>c</cei:sup>
-                            Cuius precibus ob amorem dei et reverentiam ipsius sanctae sedis
+                            </cei:narratio>
+                        <cei:dispositio>Cuius precibus ob amorem dei et reverentiam ipsius sanctae sedis
                             assensum prebuimus et hanc nostrae auctoritatis inmunitatem firmitatis
-                            gratia erga ipsum sanctum locum </cei:narratio>
-                        <cei:dispositio>fieri decrevimus per quam precipimus atque iubemus, ut sicut
+                            gratia erga ipsum sanctum locum fieri decrevimus per quam precipimus atque iubemus, ut sicut
                             a praedictis piis principibus constat eandem sedem sub eorum inmunitate
                             hactenus consistere, ita deinceps sub nostra permaneat defensione. Et
                             quicquid eidem aecclesiae retroactis temporibus

--- a/StPCanReg/1058_X_02.cei.xml
+++ b/StPCanReg/1058_X_02.cei.xml
@@ -66,7 +66,8 @@
                             quam presentibus notum esse volumus,</cei:publicatio>
                         <cei:narratio> qualiter nos ob interventum atque petitionem Agnetis
                                 dilectissime<cei:sup>c</cei:sup> genitricis nostre imperatricis
-                            auguste pro anima cari genitoris nostri Heinrici imperatoris memorie
+                            auguste</cei:narratio>
+                        <cei:dispositio> pro anima cari genitoris nostri Heinrici imperatoris memorie
                             felicis III regales mansos in loco Mandeswerede infra Svechant et
                                 Viskaha<cei:sup>d</cei:sup> iuxta Danubium, quam proxime fieri
                             possit, in marchia Osterriche et in comitatu Ernestes marchionis sitos
@@ -80,8 +81,7 @@
                             silvis venationibus aquis aquarumque de cursibus molis molendinis
                             piscationibus exitibus et reditibus viis et inviis quesitis et
                             inquirendis seu cum omni usu qui inde per venire potest et forum in
-                            Sancto Ypolito</cei:narratio>
-                        <cei:dispositio> in proprium dedimus atque tradidimus.</cei:dispositio>
+                            Sancto Ypolito in proprium dedimus atque tradidimus.</cei:dispositio>
                         <cei:corroboratio> Et ut hec nostra raegalis<cei:sup>h</cei:sup> traditio
                             stabilis et inconvulsa omni permaneat evo, hanc paginam inde conscribi
                             manuque propria ut subtus videtur corroborantes sigilli nostri


### PR DESCRIPTION
It turns out that in many files the section limits of the narratio and
the dispositio have been badly chosen. Therefore revise all files with
regards to the characteristics described in the classical diplomatics
hand book written by Harry Bresslau (Harry Bresslau, Handbuch der
Urkundenlehre fuer Deutschland und Italien Bd. 1, vierte Aufl. Berlin
1969) in order to secure the usability and liability of the annotation.